### PR TITLE
New Plugin Custom-theme

### DIFF
--- a/custom/themes/README
+++ b/custom/themes/README
@@ -1,0 +1,2 @@
+Add here your personnal theme.
+Will override any theme with the same name in oh-my-fish/themes

--- a/plugins/README.markdown
+++ b/plugins/README.markdown
@@ -4,6 +4,7 @@
 * __brew__  [Homebrew](http://brew.sh/) integration
 * __bundler__ use Ruby's [Bundler](http://bundler.io/) automatically for some commands
 * __django__  - helper for Django Unit tests. Cleans the cached modules as well.
+* __custom-theme__ - detect change in themes, and will warn you if it has changed. Fallback to system theme, if the shell is run from a tty.
 * __ec2__ - exports env variables for Amazon's EC2 management
 * __emoji__-clock - The current time with half hour accuracy as an emoji symbol
 * __extract__ - Plugin to expand or extract bundled & compressed files

--- a/plugins/custom-theme/README.md
+++ b/plugins/custom-theme/README.md
@@ -1,0 +1,22 @@
+# Custom Theme
+
+### Why ?
+  If you want to tinker with your favorite theme, custom-theme will tell you on a pull if an update has been done on the theme.
+
+### What does it do ?
+
+  The Plugin will check the latest commit of `(oh-my-fish-path)/themes/$fish_theme/fish_prompt.fish` and `(oh-my-fish-path)/themes/$fish_theme/fish_right_prompt.fish`.
+  
+  If this commit is more recent than the commit it has previously seen, custom-theme will print a warning.
+  To aknowledge this warning, just update your custom theme or `touch (oh-my-fish-path)/themes/$fish_theme/fish_prompt.fish`
+
+
+### Other Features
+
+  Many themes use color and unicode that doesn't really fit a system tty ;
+  * This is why custom-theme also perform a fallback on system `fish_prompt` if it detect that fish is launched from a ttyX.
+
+
+### How to use ?
+
+  This plugin also have a folder in `themes`, do not worry about that just add this plugin like any other `set fish_plugin custom-theme`

--- a/plugins/custom-theme/__customtheme_fish_prompt.fish
+++ b/plugins/custom-theme/__customtheme_fish_prompt.fish
@@ -10,23 +10,24 @@ function __customtheme_fish_prompt
   set -l theme_path $__customtheme_oh_my_fish_path/themes/$fish_custom_theme/fish_prompt.fish
   set -l custom_path $__customtheme_oh_my_fish_path/custom/themes/$fish_custom_theme/fish_prompt.fish
 
-  set -l theme_version __customtheme_theme_prompt_version_$fish_custom_theme
-  set -l custom_version __customtheme_custom_prompt_version_$fish_custom_theme
+  set -l theme_version "__customtheme_theme_prompt_version_$fish_custom_theme"
+  set -l custom_version "__customtheme_custom_prompt_version_$fish_custom_theme"
 
   if set -q __customtheme_git_check_ok
-    if test -f "$theme_path" ; and test -f "$custom_path"
+    if test -f "$theme_path" -a -f "$custom_path"
       set -l current_theme_version (command git log -n 1 -- "$theme_path" | command grep commit)
 
       if not set -q $theme_version 
         set -U $theme_version $current_theme_version
 
     # The theme has been changed !
-      else if not test $$theme_version = $current_theme_version
+      else if not test $$theme_version = "$current_theme_version"
         set -l current_custom_version (command ls -lon --time-style +%s "$custom_path"|\
         command sed 's- /.*$--;s/^\([^0-9]*[0-9]\+\)\{3\} //')
         if not set -q $custom_version
           set -U $custom_version $current_custom_version
-        else if test $$custom_version = $current_custom_version
+	  set retval 1
+        else if test $$custom_version = "$current_custom_version"
           set retval 1
         else
           set -U $theme_version $current_theme_version

--- a/plugins/custom-theme/__customtheme_fish_prompt.fish
+++ b/plugins/custom-theme/__customtheme_fish_prompt.fish
@@ -4,17 +4,16 @@ function __customtheme_fish_prompt
   # Testing the current version of the theme against the current custom
   # Print a warning if the file has been changed.
   # Assuming classic installation, oh-my-fish is a git repo
-  set -l oh_my_fish_path (status -f|command sed 's-/custom.*\?$--')
-  set -lx GIT_DIR "$oh_my_fish_path/.git"
-  set -lx GIT_WORK_TREE "$oh_my_fish_path"
+  set -lx GIT_DIR "$__customtheme_oh_my_fish_path/.git"
+  set -lx GIT_WORK_TREE "$__customtheme_oh_my_fish_path"
 
-  set -l theme_path $oh_my_fish_path/themes/$fish_custom_theme/fish_prompt.fish
-  set -l custom_path $oh_my_fish_path/custom/themes/$fish_custom_theme/fish_prompt.fish
+  set -l theme_path $__customtheme_oh_my_fish_path/themes/$fish_custom_theme/fish_prompt.fish
+  set -l custom_path $__customtheme_oh_my_fish_path/custom/themes/$fish_custom_theme/fish_prompt.fish
 
   set -l theme_version __customtheme_theme_prompt_version_$fish_custom_theme
   set -l custom_version __customtheme_custom_prompt_version_$fish_custom_theme
 
-  if command git status > /dev/null ^&1
+  if set -q __customtheme_git_check_ok
     if test -f "$theme_path" ; and test -f "$custom_path"
       set -l current_theme_version (command git log -n 1 -- "$theme_path" | grep commit)
       set -l current_custom_version (command ls -lon --time-style +%s "$custom_path"|\

--- a/plugins/custom-theme/__customtheme_fish_prompt.fish
+++ b/plugins/custom-theme/__customtheme_fish_prompt.fish
@@ -18,20 +18,20 @@ function __customtheme_fish_prompt
       set -l current_theme_version (command git log -n 1 -- "$theme_path" | command grep commit)
 
       if not set -q $theme_version 
-  		  set -U $theme_version $current_theme_version
+        set -U $theme_version $current_theme_version
 
-		# The theme has been changed !
+    # The theme has been changed !
       else if not test $$theme_version = $current_theme_version
-  		  set -l current_custom_version (command ls -lon --time-style +%s "$custom_path"|\
-  		  command sed 's- /.*$--;s/^\([^0-9]*[0-9]\+\)\{3\} //')
-		  if not set -q $custom_version
-  			 set -U $custom_version $current_custom_version
-		  else if test $$custom_version = $current_custom_version
-			 set retval 1
-		  else
-			 set -U $theme_version $current_theme_version
-			 set -e $custom_version
-		  end
+        set -l current_custom_version (command ls -lon --time-style +%s "$custom_path"|\
+        command sed 's- /.*$--;s/^\([^0-9]*[0-9]\+\)\{3\} //')
+        if not set -q $custom_version
+          set -U $custom_version $current_custom_version
+        else if test $$custom_version = $current_custom_version
+          set retval 1
+        else
+          set -U $theme_version $current_theme_version
+          set -e $custom_version
+        end
       end
     end
   end

--- a/plugins/custom-theme/__customtheme_fish_prompt.fish
+++ b/plugins/custom-theme/__customtheme_fish_prompt.fish
@@ -1,4 +1,5 @@
 function __customtheme_fish_prompt
+  set -l retval 0
 
   # Testing the current version of the theme against the current custom
   # Print a warning if the file has been changed.
@@ -27,9 +28,7 @@ function __customtheme_fish_prompt
 		# The theme has been changed !
       else if not test $$theme_version = $current_theme_version
 		  if test $$custom_version = $current_custom_version
-			 set_color red
-  			 echo -e "The theme '$fish_custom_theme' has been changed.\nAn update to your custom file is necessary."
-			 set_color normal
+			 set retval 1
 		  else
 			 set -U $theme_version $current_theme_version
 			 set -U $custom_version $current_custom_version
@@ -41,4 +40,5 @@ function __customtheme_fish_prompt
     end
   end
 
+  return $retval
 end

--- a/plugins/custom-theme/__customtheme_fish_prompt.fish
+++ b/plugins/custom-theme/__customtheme_fish_prompt.fish
@@ -1,0 +1,40 @@
+function __customtheme_fish_prompt
+
+  # Testing the current version of the theme against the current custom
+  # Print a warning if the file has been changed.
+  # Assuming classic installation, oh-my-fish is a git repo
+  set -l oh_my_fish_path (status -f|command sed 's-/custom.*\?$--')
+  set -lx GIT_DIR "$oh_my_fish_path/.git"
+  set -lx GIT_WORK_TREE "$oh_my_fish_path"
+
+  set -l theme_path $oh_my_fish_path/themes/$fish_custom_theme/fish_prompt.fish
+  set -l custom_path $oh_my_fish_path/custom/themes/$fish_custom_theme/fish_prompt.fish
+
+  set -l theme_version __customtheme_theme_prompt_version_$fish_custom_theme
+  set -l custom_version __customtheme_custom_prompt_version_$fish_custom_theme
+
+  if command git status > /dev/null ^&1
+    if test -f "$theme_path" ; and test -f "$custom_path"
+      set -l current_theme_version (command git log -n 1 -- "$theme_path" | grep commit)
+      set -l current_custom_version (command ls -lon --time-style +%s "$custom_path"|\
+      sed 's- /.*$--;s/^\([^0-9]*[0-9]\+\)\{3\} //')
+
+      if not set -q $theme_version 
+    	   or not set -q $custom_version
+
+  	   set -U $theme_version $current_theme_version
+  	   set -U $custom_version $current_custom_version
+      else if not test $$theme_version = $current_theme_version
+  	   if test $$custom_version = $current_custom_version
+    		  set_color red
+  	  	  echo -e "The theme '$fish_custom_theme' has been changed.\nAn update to your custom file is necessary."
+    		  set_color normal
+  	   else
+  		  set -U $theme_version $current_theme_version
+    		  set -U $custom_version $current_custom_version
+  	   end
+      end
+    end
+  end
+
+end

--- a/plugins/custom-theme/__customtheme_fish_prompt.fish
+++ b/plugins/custom-theme/__customtheme_fish_prompt.fish
@@ -15,26 +15,23 @@ function __customtheme_fish_prompt
 
   if set -q __customtheme_git_check_ok
     if test -f "$theme_path" ; and test -f "$custom_path"
-      set -l current_theme_version (command git log -n 1 -- "$theme_path" | grep commit)
-      set -l current_custom_version (command ls -lon --time-style +%s "$custom_path"|\
-      sed 's- /.*$--;s/^\([^0-9]*[0-9]\+\)\{3\} //')
+      set -l current_theme_version (command git log -n 1 -- "$theme_path" | command grep commit)
 
       if not set -q $theme_version 
-		  or not set -q $custom_version
   		  set -U $theme_version $current_theme_version
-  		  set -U $custom_version $current_custom_version
 
 		# The theme has been changed !
       else if not test $$theme_version = $current_theme_version
-		  if test $$custom_version = $current_custom_version
+  		  set -l current_custom_version (command ls -lon --time-style +%s "$custom_path"|\
+  		  command sed 's- /.*$--;s/^\([^0-9]*[0-9]\+\)\{3\} //')
+		  if not set -q $custom_version
+  			 set -U $custom_version $current_custom_version
+		  else if test $$custom_version = $current_custom_version
 			 set retval 1
 		  else
 			 set -U $theme_version $current_theme_version
-			 set -U $custom_version $current_custom_version
+			 set -e $custom_version
 		  end
-		# The Theme hasn't been changed, but the custom file has.
-		else if test $$custom_version != $current_custom_version
-  		  set -U $custom_version $current_custom_version
       end
     end
   end

--- a/plugins/custom-theme/__customtheme_fish_prompt.fish
+++ b/plugins/custom-theme/__customtheme_fish_prompt.fish
@@ -20,19 +20,23 @@ function __customtheme_fish_prompt
       sed 's- /.*$--;s/^\([^0-9]*[0-9]\+\)\{3\} //')
 
       if not set -q $theme_version 
-    	   or not set -q $custom_version
-
-  	   set -U $theme_version $current_theme_version
-  	   set -U $custom_version $current_custom_version
-      else if not test $$theme_version = $current_theme_version
-  	   if test $$custom_version = $current_custom_version
-    		  set_color red
-  	  	  echo -e "The theme '$fish_custom_theme' has been changed.\nAn update to your custom file is necessary."
-    		  set_color normal
-  	   else
+		  or not set -q $custom_version
   		  set -U $theme_version $current_theme_version
-    		  set -U $custom_version $current_custom_version
-  	   end
+  		  set -U $custom_version $current_custom_version
+
+		# The theme has been changed !
+      else if not test $$theme_version = $current_theme_version
+		  if test $$custom_version = $current_custom_version
+			 set_color red
+  			 echo -e "The theme '$fish_custom_theme' has been changed.\nAn update to your custom file is necessary."
+			 set_color normal
+		  else
+			 set -U $theme_version $current_theme_version
+			 set -U $custom_version $current_custom_version
+		  end
+		# The Theme hasn't been changed, but the custom file has.
+		else if test $$custom_version != $current_custom_version
+  		  set -U $custom_version $current_custom_version
       end
     end
   end

--- a/plugins/custom-theme/__customtheme_fish_right_prompt.fish
+++ b/plugins/custom-theme/__customtheme_fish_right_prompt.fish
@@ -15,26 +15,23 @@ function __customtheme_fish_right_prompt
 
   if set -q __customtheme_git_check_ok
     if test -f "$theme_path" ; and test -f "$custom_path"
-      set -l current_theme_version (command git log -n 1 -- "$theme_path" | grep commit)
-      set -l current_custom_version (command ls -lon --time-style +%s "$custom_path"|\
-      sed 's- /.*$--;s/^\([^0-9]*[0-9]\+\)\{3\} //')
+      set -l current_theme_version (command git log -n 1 -- "$theme_path" | command grep commit)
 
       if not set -q $theme_version 
-		  or not set -q $custom_version
   		  set -U $theme_version $current_theme_version
-  		  set -U $custom_version $current_custom_version
 
 		# The theme has been changed !
       else if not test $$theme_version = $current_theme_version
-		  if test $$custom_version = $current_custom_version
+  		  set -l current_custom_version (command ls -lon --time-style +%s "$custom_path"|\
+  		  command sed 's- /.*$--;s/^\([^0-9]*[0-9]\+\)\{3\} //')
+		  if not set -q $custom_version
+  			 set -U $custom_version $current_custom_version
+		  else if test $$custom_version = $current_custom_version
 			 set retval 1
 		  else
 			 set -U $theme_version $current_theme_version
-			 set -U $custom_version $current_custom_version
+			 set -e $custom_version
 		  end
-		# The Theme hasn't been changed, but the custom file has.
-		else if test $$custom_version != $current_custom_version
-  		  set -U $custom_version $current_custom_version
       end
     end
   end

--- a/plugins/custom-theme/__customtheme_fish_right_prompt.fish
+++ b/plugins/custom-theme/__customtheme_fish_right_prompt.fish
@@ -1,4 +1,5 @@
 function __customtheme_fish_right_prompt
+  set -l retval 0
 
   # Testing the current version of the theme against the current custom
   # Print a warning if the file has been changed.
@@ -27,9 +28,7 @@ function __customtheme_fish_right_prompt
 		# The theme has been changed !
       else if not test $$theme_version = $current_theme_version
 		  if test $$custom_version = $current_custom_version
-			 set_color red
-  			 echo -e "The theme '$fish_custom_theme' has been changed.\nAn update to your fish_right_prompt.fish is necessary."
-			 set_color normal
+			 set retval 1
 		  else
 			 set -U $theme_version $current_theme_version
 			 set -U $custom_version $current_custom_version
@@ -41,4 +40,5 @@ function __customtheme_fish_right_prompt
     end
   end
 
+  return $retval
 end

--- a/plugins/custom-theme/__customtheme_fish_right_prompt.fish
+++ b/plugins/custom-theme/__customtheme_fish_right_prompt.fish
@@ -10,11 +10,11 @@ function __customtheme_fish_right_prompt
   set -l theme_path $__customtheme_oh_my_fish_path/themes/$fish_custom_theme/fish_right_prompt.fish
   set -l custom_path $__customtheme_oh_my_fish_path/custom/themes/$fish_custom_theme/fish_right_prompt.fish
 
-  set -l theme_version __customtheme_theme_right_prompt_version_$fish_custom_theme
-  set -l custom_version __customtheme_custom_right_prompt_version_$fish_custom_theme
+  set -l theme_version "__customtheme_theme_right_prompt_version_$fish_custom_theme"
+  set -l custom_version "__customtheme_custom_right_prompt_version_$fish_custom_theme"
 
   if set -q __customtheme_git_check_ok
-    if test -f "$theme_path" ; and test -f "$custom_path"
+    if begin; test -f "$theme_path" ; and test -f "$custom_path"; end;
       set -l current_theme_version (command git log -n 1 -- "$theme_path" | command grep commit)
 
       if not set -q $theme_version 
@@ -26,6 +26,7 @@ function __customtheme_fish_right_prompt
         command sed 's- /.*$--;s/^\([^0-9]*[0-9]\+\)\{3\} //')
         if not set -q $custom_version
           set -U $custom_version $current_custom_version
+          set retval 1
         else if test $$custom_version = $current_custom_version
           set retval 1
         else

--- a/plugins/custom-theme/__customtheme_fish_right_prompt.fish
+++ b/plugins/custom-theme/__customtheme_fish_right_prompt.fish
@@ -18,20 +18,20 @@ function __customtheme_fish_right_prompt
       set -l current_theme_version (command git log -n 1 -- "$theme_path" | command grep commit)
 
       if not set -q $theme_version 
-  		  set -U $theme_version $current_theme_version
+        set -U $theme_version $current_theme_version
 
-		# The theme has been changed !
+    # The theme has been changed !
       else if not test $$theme_version = $current_theme_version
-  		  set -l current_custom_version (command ls -lon --time-style +%s "$custom_path"|\
-  		  command sed 's- /.*$--;s/^\([^0-9]*[0-9]\+\)\{3\} //')
-		  if not set -q $custom_version
-  			 set -U $custom_version $current_custom_version
-		  else if test $$custom_version = $current_custom_version
-			 set retval 1
-		  else
-			 set -U $theme_version $current_theme_version
-			 set -e $custom_version
-		  end
+        set -l current_custom_version (command ls -lon --time-style +%s "$custom_path"|\
+        command sed 's- /.*$--;s/^\([^0-9]*[0-9]\+\)\{3\} //')
+        if not set -q $custom_version
+          set -U $custom_version $current_custom_version
+        else if test $$custom_version = $current_custom_version
+          set retval 1
+        else
+          set -U $theme_version $current_theme_version
+          set -e $custom_version
+        end
       end
     end
   end

--- a/plugins/custom-theme/__customtheme_fish_right_prompt.fish
+++ b/plugins/custom-theme/__customtheme_fish_right_prompt.fish
@@ -1,0 +1,40 @@
+function __customtheme_fish_right_prompt
+
+  # Testing the current version of the theme against the current custom
+  # Print a warning if the file has been changed.
+  # Assuming classic installation, oh-my-fish is a git repo
+  set -l oh_my_fish_path (status -f|sed 's-/custom.*\?$--')
+  set -lx GIT_DIR "$oh_my_fish_path/.git"
+  set -lx GIT_WORK_TREE "$oh_my_fish_path"
+
+  set -l theme_path $oh_my_fish_path/themes/$fish_custom_theme/fish_right_prompt.fish
+  set -l custom_path $oh_my_fish_path/custom/themes/$fish_custom_theme/fish_right_prompt.fish
+
+  set -l theme_version __customtheme_theme_right_prompt_version_$fish_custom_theme
+  set -l custom_version __customtheme_custom_right_prompt_version_$fish_custom_theme
+
+  if git status > /dev/null ^&1
+    if test -f "$theme_path" ; and test -f "$custom_path"
+      set -l current_theme_version (git log -n 1 -- $theme_path | grep commit)
+      set -l current_custom_version (command ls -lon --time-style +%s "$custom_path"|\
+      sed 's- /.*$--;s/^\([^0-9]*[0-9]\+\)\{3\} //')
+
+      if not set -q $theme_version 
+    	   or not set -q $custom_version
+
+  	   set -U $theme_version $current_theme_version
+  	   set -U $custom_version $current_custom_version
+      else if not test $$theme_version = $current_theme_version
+  	   if test $$custom_version = $current_custom_version
+    		  set_color red
+  	  	  echo -e "The theme '$fish_custom_theme' has been changed.\nAn update to your fish_right_prompt.fish is necessary."
+    		  set_color normal
+  	   else
+  		  set -U $theme_version $current_theme_version
+    		  set -U $custom_version $current_custom_version
+  	   end
+      end
+    end
+  end
+
+end

--- a/plugins/custom-theme/__customtheme_fish_right_prompt.fish
+++ b/plugins/custom-theme/__customtheme_fish_right_prompt.fish
@@ -3,7 +3,7 @@ function __customtheme_fish_right_prompt
   # Testing the current version of the theme against the current custom
   # Print a warning if the file has been changed.
   # Assuming classic installation, oh-my-fish is a git repo
-  set -l oh_my_fish_path (status -f|sed 's-/custom.*\?$--')
+  set -l oh_my_fish_path (status -f|command sed 's-/custom.*\?$--')
   set -lx GIT_DIR "$oh_my_fish_path/.git"
   set -lx GIT_WORK_TREE "$oh_my_fish_path"
 
@@ -13,26 +13,30 @@ function __customtheme_fish_right_prompt
   set -l theme_version __customtheme_theme_right_prompt_version_$fish_custom_theme
   set -l custom_version __customtheme_custom_right_prompt_version_$fish_custom_theme
 
-  if git status > /dev/null ^&1
+  if command git status > /dev/null ^&1
     if test -f "$theme_path" ; and test -f "$custom_path"
-      set -l current_theme_version (git log -n 1 -- $theme_path | grep commit)
+      set -l current_theme_version (command git log -n 1 -- "$theme_path" | grep commit)
       set -l current_custom_version (command ls -lon --time-style +%s "$custom_path"|\
       sed 's- /.*$--;s/^\([^0-9]*[0-9]\+\)\{3\} //')
 
       if not set -q $theme_version 
-    	   or not set -q $custom_version
-
-  	   set -U $theme_version $current_theme_version
-  	   set -U $custom_version $current_custom_version
-      else if not test $$theme_version = $current_theme_version
-  	   if test $$custom_version = $current_custom_version
-    		  set_color red
-  	  	  echo -e "The theme '$fish_custom_theme' has been changed.\nAn update to your fish_right_prompt.fish is necessary."
-    		  set_color normal
-  	   else
+		  or not set -q $custom_version
   		  set -U $theme_version $current_theme_version
-    		  set -U $custom_version $current_custom_version
-  	   end
+  		  set -U $custom_version $current_custom_version
+
+		# The theme has been changed !
+      else if not test $$theme_version = $current_theme_version
+		  if test $$custom_version = $current_custom_version
+			 set_color red
+  			 echo -e "The theme '$fish_custom_theme' has been changed.\nAn update to your fish_right_prompt.fish is necessary."
+			 set_color normal
+		  else
+			 set -U $theme_version $current_theme_version
+			 set -U $custom_version $current_custom_version
+		  end
+		# The Theme hasn't been changed, but the custom file has.
+		else if test $$custom_version != $current_custom_version
+  		  set -U $custom_version $current_custom_version
       end
     end
   end

--- a/plugins/custom-theme/__customtheme_fish_right_prompt.fish
+++ b/plugins/custom-theme/__customtheme_fish_right_prompt.fish
@@ -4,17 +4,16 @@ function __customtheme_fish_right_prompt
   # Testing the current version of the theme against the current custom
   # Print a warning if the file has been changed.
   # Assuming classic installation, oh-my-fish is a git repo
-  set -l oh_my_fish_path (status -f|command sed 's-/custom.*\?$--')
-  set -lx GIT_DIR "$oh_my_fish_path/.git"
-  set -lx GIT_WORK_TREE "$oh_my_fish_path"
+  set -lx GIT_DIR "$__customtheme_oh_my_fish_path/.git"
+  set -lx GIT_WORK_TREE "$__customtheme_oh_my_fish_path"
 
-  set -l theme_path $oh_my_fish_path/themes/$fish_custom_theme/fish_right_prompt.fish
-  set -l custom_path $oh_my_fish_path/custom/themes/$fish_custom_theme/fish_right_prompt.fish
+  set -l theme_path $__customtheme_oh_my_fish_path/themes/$fish_custom_theme/fish_right_prompt.fish
+  set -l custom_path $__customtheme_oh_my_fish_path/custom/themes/$fish_custom_theme/fish_right_prompt.fish
 
   set -l theme_version __customtheme_theme_right_prompt_version_$fish_custom_theme
   set -l custom_version __customtheme_custom_right_prompt_version_$fish_custom_theme
 
-  if command git status > /dev/null ^&1
+  if set -q __customtheme_git_check_ok
     if test -f "$theme_path" ; and test -f "$custom_path"
       set -l current_theme_version (command git log -n 1 -- "$theme_path" | grep commit)
       set -l current_custom_version (command ls -lon --time-style +%s "$custom_path"|\

--- a/plugins/custom-theme/custom-theme.load
+++ b/plugins/custom-theme/custom-theme.load
@@ -12,3 +12,20 @@ function __customtheme_check_prompt --on-event fish_prompt -d 'Check your custom
   __customtheme_fish_prompt
   __customtheme_fish_right_prompt
 end
+
+function __load_system_fish_prompt
+  if test -f /etc/fish/functions/fish_prompt.fish
+	 source /etc/fish/functions/fish_prompt.fish
+  else if test -f /usr/share/fish/functions/fish_prompt.fish
+  	 source /usr/share/fish/functions/fish_prompt.fish
+  end
+end
+
+function __load_system_fish_right_prompt
+  if test -f /etc/fish/functions/fish_right_prompt.fish
+	 source /etc/fish/functions/fish_right_prompt.fish
+  else if test -f /usr/share/fish/functions/fish_right_prompt.fish
+  	 source /usr/share/fish/functions/fish_right_prompt.fish
+  end
+end
+

--- a/plugins/custom-theme/custom-theme.load
+++ b/plugins/custom-theme/custom-theme.load
@@ -15,29 +15,33 @@ function __customtheme_init_global
     if test $fish_theme != custom-theme
       set -g fish_custom_theme $fish_theme
       set fish_theme custom-theme
+      _append_path $fish_path/themes/$fish_custom_theme fish_function_path
+      _append_path $fish_custom/themes/$fish_custom_theme fish_function_path
     end
   end
 
 end
 
 function __customtheme_check_prompt --on-event fish_prompt -d 'Check your custom theme against the vanilla one.'
-  __customtheme_fish_prompt
-  set -l retval_fish_prompt $status
-  __customtheme_fish_right_prompt
-  set -l retval_fish_right_prompt $status
+  if test -e "$PWD"
+    __customtheme_fish_prompt
+    set -l retval_fish_prompt $status
+    __customtheme_fish_right_prompt
+    set -l retval_fish_right_prompt $status
 
-  if test $retval_fish_prompt -ne 0 -o $retval_fish_right_prompt -ne 0
-    set_color -b white red
-    echo The theme $fish_custom_theme has been changed.
+    if test "$retval_fish_prompt" -ne 0 -o "$retval_fish_right_prompt" -ne 0
+      set_color -b white red
+      echo The theme $fish_custom_theme has been changed.
 
-    if test $retval_fish_prompt -ne 0
-      echo Please check your fish_prompt.fish file.
+      if test $retval_fish_prompt -ne 0
+        echo Please check your fish_prompt.fish file.
+      end
+      if test $retval_fish_right_prompt -ne 0
+        echo Please check your fish_right_prompt.fish file.
+      end
+
+      set_color normal
     end
-    if test $retval_fish_right_prompt -ne 0
-      echo Please check your fish_right_prompt.fish file.
-    end
-
-    set_color normal
   end
 end
 

--- a/plugins/custom-theme/custom-theme.load
+++ b/plugins/custom-theme/custom-theme.load
@@ -1,11 +1,23 @@
 # Dynamic custom Theme loader
 # Will notice you if the original theme your custom theme is based on has changed.
 
-if set -q fish_theme
-  if test $fish_theme != custom-theme
-    set -g fish_custom_theme $fish_theme
-    set fish_theme custom-theme
+function __customtheme_init_global
+  set -g __customtheme_oh_my_fish_path (status -f|command sed 's-/custom.*\?$--')
+
+  set -lx GIT_DIR "$__customtheme_oh_my_fish_path/.git"
+  set -lx GIT_WORK_TREE "$__customtheme_oh_my_fish_path"
+
+  if command git status > /dev/null ^&1
+	 set -g __customtheme_git_check_ok
   end
+
+  if set -q fish_theme
+	 if test $fish_theme != custom-theme
+		set -g fish_custom_theme $fish_theme
+  		set fish_theme custom-theme
+    end
+  end
+
 end
 
 function __customtheme_check_prompt --on-event fish_prompt -d 'Check your custom theme against the vanilla one.'
@@ -45,3 +57,5 @@ function __load_system_fish_right_prompt
   end
 end
 
+
+__customtheme_init_global

--- a/plugins/custom-theme/custom-theme.load
+++ b/plugins/custom-theme/custom-theme.load
@@ -10,7 +10,23 @@ end
 
 function __customtheme_check_prompt --on-event fish_prompt -d 'Check your custom theme against the vanilla one.'
   __customtheme_fish_prompt
+  set -l retval_fish_prompt $status
   __customtheme_fish_right_prompt
+  set -l retval_fish_right_prompt $status
+
+  if test $retval_fish_prompt -ne 0 -o $retval_fish_right_prompt -ne 0
+	 set_color -b white red
+	 echo The theme $fish_custom_theme has been changed.
+
+	 if test $retval_fish_prompt -ne 0
+		echo Please check your fish_prompt.fish file.
+	 end
+	 if test $retval_fish_right_prompt -ne 0
+		echo Please check your fish_right_prompt.fish file.
+	 end
+
+	 set_color normal
+  end
 end
 
 function __load_system_fish_prompt

--- a/plugins/custom-theme/custom-theme.load
+++ b/plugins/custom-theme/custom-theme.load
@@ -8,13 +8,13 @@ function __customtheme_init_global
   set -lx GIT_WORK_TREE "$__customtheme_oh_my_fish_path"
 
   if command git status > /dev/null ^&1
-	 set -g __customtheme_git_check_ok
+    set -g __customtheme_git_check_ok
   end
 
   if set -q fish_theme
-	 if test $fish_theme != custom-theme
-		set -g fish_custom_theme $fish_theme
-  		set fish_theme custom-theme
+    if test $fish_theme != custom-theme
+      set -g fish_custom_theme $fish_theme
+      set fish_theme custom-theme
     end
   end
 
@@ -27,33 +27,33 @@ function __customtheme_check_prompt --on-event fish_prompt -d 'Check your custom
   set -l retval_fish_right_prompt $status
 
   if test $retval_fish_prompt -ne 0 -o $retval_fish_right_prompt -ne 0
-	 set_color -b white red
-	 echo The theme $fish_custom_theme has been changed.
+    set_color -b white red
+    echo The theme $fish_custom_theme has been changed.
 
-	 if test $retval_fish_prompt -ne 0
-		echo Please check your fish_prompt.fish file.
-	 end
-	 if test $retval_fish_right_prompt -ne 0
-		echo Please check your fish_right_prompt.fish file.
-	 end
+    if test $retval_fish_prompt -ne 0
+      echo Please check your fish_prompt.fish file.
+    end
+    if test $retval_fish_right_prompt -ne 0
+      echo Please check your fish_right_prompt.fish file.
+    end
 
-	 set_color normal
+    set_color normal
   end
 end
 
 function __load_system_fish_prompt
   if test -f $__fish_sysconfdir/functions/fish_prompt.fish
-	 source $__fish_sysconfdir/functions/fish_prompt.fish
+    source $__fish_sysconfdir/functions/fish_prompt.fish
   else if test -f $__fish_datadir/functions/fish_prompt.fish
-  	 source $__fish_datadir/functions/fish_prompt.fish
+    source $__fish_datadir/functions/fish_prompt.fish
   end
 end
 
 function __load_system_fish_right_prompt
   if test -f $__fish_sysconfdir/functions/fish_right_prompt.fish
-	 source $__fish_sysconfdir/functions/fish_right_prompt.fish
+    source $__fish_sysconfdir/functions/fish_right_prompt.fish
   else if test -f $__fish_datadir/functions/fish_right_prompt.fish
-  	 source $__fish_datadir/functions/fish_right_prompt.fish
+    source $__fish_datadir/functions/fish_right_prompt.fish
   end
 end
 

--- a/plugins/custom-theme/custom-theme.load
+++ b/plugins/custom-theme/custom-theme.load
@@ -7,3 +7,8 @@ if set -q fish_theme
     set fish_theme custom-theme
   end
 end
+
+function __customtheme_check_prompt --on-event fish_prompt -d 'Check your custom theme against the vanilla one.'
+  __customtheme_fish_prompt
+  __customtheme_fish_right_prompt
+end

--- a/plugins/custom-theme/custom-theme.load
+++ b/plugins/custom-theme/custom-theme.load
@@ -42,18 +42,18 @@ function __customtheme_check_prompt --on-event fish_prompt -d 'Check your custom
 end
 
 function __load_system_fish_prompt
-  if test -f /etc/fish/functions/fish_prompt.fish
-	 source /etc/fish/functions/fish_prompt.fish
-  else if test -f /usr/share/fish/functions/fish_prompt.fish
-  	 source /usr/share/fish/functions/fish_prompt.fish
+  if test -f $__fish_sysconfdir/functions/fish_prompt.fish
+	 source $__fish_sysconfdir/functions/fish_prompt.fish
+  else if test -f $__fish_datadir/functions/fish_prompt.fish
+  	 source $__fish_datadir/functions/fish_prompt.fish
   end
 end
 
 function __load_system_fish_right_prompt
-  if test -f /etc/fish/functions/fish_right_prompt.fish
-	 source /etc/fish/functions/fish_right_prompt.fish
-  else if test -f /usr/share/fish/functions/fish_right_prompt.fish
-  	 source /usr/share/fish/functions/fish_right_prompt.fish
+  if test -f $__fish_sysconfdir/functions/fish_right_prompt.fish
+	 source $__fish_sysconfdir/functions/fish_right_prompt.fish
+  else if test -f $__fish_datadir/functions/fish_right_prompt.fish
+  	 source $__fish_datadir/functions/fish_right_prompt.fish
   end
 end
 

--- a/plugins/custom-theme/custom-theme.load
+++ b/plugins/custom-theme/custom-theme.load
@@ -1,0 +1,9 @@
+# Dynamic custom Theme loader
+# Will notice you if the original theme your custom theme is based on has changed.
+
+if set -q fish_theme
+  if test $fish_theme != custom-theme
+    set -g fish_custom_theme $fish_theme
+    set fish_theme custom-theme
+  end
+end

--- a/themes/custom-theme/README.md
+++ b/themes/custom-theme/README.md
@@ -1,0 +1,3 @@
+This is not a theme, see the plugin with the same name.
+
+Setting this as a theme, will just fallback to the system fish_prompt

--- a/themes/custom-theme/fish_prompt.fish
+++ b/themes/custom-theme/fish_prompt.fish
@@ -6,7 +6,9 @@ set -l custom_path $oh_my_fish_path/custom/themes/$fish_custom_theme/fish_prompt
 
 # Assuming that if COLORTERM isn't set we are in a tty
 # In a tty fallback to system fish_prompt
-if not set -q COLORTERM
+#not set -q COLORTERM; and not set -q TMUX
+#if test x$status = x'0'
+if test x$TERM = x'linux'
   __load_system_fish_prompt
 else if test -f "$custom_path"
   source $custom_path

--- a/themes/custom-theme/fish_prompt.fish
+++ b/themes/custom-theme/fish_prompt.fish
@@ -1,41 +1,8 @@
 
-# Testing the current version of the theme against the current custom
-# Print a warning if the file has been changed.
-# Assuming classic installation, oh-my-fish is a git repo
-set -l oh_my_fish_path (status -f|sed 's-/custom.*\?$--')
-set -lx GIT_DIR "$oh_my_fish_path/.git"
-set -lx GIT_WORK_TREE "$oh_my_fish_path"
+set -l oh_my_fish_path (status -f|command sed 's-/custom.*\?$--')
 
 set -l theme_path $oh_my_fish_path/themes/$fish_custom_theme/fish_prompt.fish
 set -l custom_path $oh_my_fish_path/custom/themes/$fish_custom_theme/fish_prompt.fish
-
-set -l theme_version __customtheme_theme_prompt_version_$fish_custom_theme
-set -l custom_version __customtheme_custom_prompt_version_$fish_custom_theme
-
-if git status > /dev/null ^&1
-  if test -f "$theme_path" ; and test -f "$custom_path"
-	 echo $custom_path
-    set -l current_theme_version (git log -n 1 -- $theme_path | grep commit)
-    set -l current_custom_version (command ls -lon --time-style +%s "$custom_path"|\
-    sed 's- /.*$--;s/^\([^0-9]*[0-9]\+\)\{3\} //')
-
-    if not set -q $theme_version 
-  	   or not set -q $custom_version
-
-	   set -U $theme_version $current_theme_version
-	   set -U $custom_version $current_custom_version
-    else if not test $$theme_version = $current_theme_version
-	   if test $$custom_version = $current_custom_version
-  		  set_color red
-	  	  echo -e "The theme '$fish_custom_theme' has been changed.\nAn update to your custom file is necessary."
-  		  set_color normal
-	   else
-		  set -U $theme_version $current_theme_version
-  		  set -U $custom_version $current_custom_version
-	   end
-    end
-  end
-end
 
 function __load_system_fish_prompt
   if test -f /etc/fish/functions/fish_prompt.fish

--- a/themes/custom-theme/fish_prompt.fish
+++ b/themes/custom-theme/fish_prompt.fish
@@ -1,5 +1,5 @@
 
-set -l oh_my_fish_path (status -f|command sed 's-/custom.*\?$--')
+set -l oh_my_fish_path (status -f|command sed -r 's#(/custom)?/themes/custom-theme.*?$##')
 
 set -l theme_path $oh_my_fish_path/themes/$fish_custom_theme/fish_prompt.fish
 set -l custom_path $oh_my_fish_path/custom/themes/$fish_custom_theme/fish_prompt.fish

--- a/themes/custom-theme/fish_prompt.fish
+++ b/themes/custom-theme/fish_prompt.fish
@@ -1,0 +1,58 @@
+
+# Testing the current version of the theme against the current custom
+# Print a warning if the file has been changed.
+# Assuming classic installation, oh-my-fish is a git repo
+set -l oh_my_fish_path (status -f|sed 's-/custom.*\?$--')
+set -lx GIT_DIR "$oh_my_fish_path/.git"
+set -lx GIT_WORK_TREE "$oh_my_fish_path"
+
+set -l theme_path $oh_my_fish_path/themes/$fish_custom_theme/fish_prompt.fish
+set -l custom_path $oh_my_fish_path/custom/themes/$fish_custom_theme/fish_prompt.fish
+
+set -l theme_version __customtheme_theme_prompt_version_$fish_custom_theme
+set -l custom_version __customtheme_custom_prompt_version_$fish_custom_theme
+
+if git status > /dev/null ^&1
+  if test -f "$theme_path" ; and test -f "$custom_path"
+	 echo $custom_path
+    set -l current_theme_version (git log -n 1 -- $theme_path | grep commit)
+    set -l current_custom_version (command ls -lon --time-style +%s "$custom_path"|\
+    sed 's- /.*$--;s/^\([^0-9]*[0-9]\+\)\{3\} //')
+
+    if not set -q $theme_version 
+  	   or not set -q $custom_version
+
+	   set -U $theme_version $current_theme_version
+	   set -U $custom_version $current_custom_version
+    else if not test $$theme_version = $current_theme_version
+	   if test $$custom_version = $current_custom_version
+  		  set_color red
+	  	  echo -e "The theme '$fish_custom_theme' has been changed.\nAn update to your custom file is necessary."
+  		  set_color normal
+	   else
+		  set -U $theme_version $current_theme_version
+  		  set -U $custom_version $current_custom_version
+	   end
+    end
+  end
+end
+
+function __load_system_fish_prompt
+  if test -f /etc/fish/functions/fish_prompt.fish
+	 source /etc/fish/functions/fish_prompt.fish
+  else if test -f /usr/share/fish/functions/fish_prompt.fish
+  	 source /usr/share/fish/functions/fish_prompt.fish
+  end
+end
+
+# Assuming that if COLORTERM isn't set we are in a tty
+# In a tty fallback to system fish_prompt
+if not set -q COLORTERM
+  __load_system_fish_prompt
+else if test -f "$custom_path"
+  source $custom_path
+else if test -f "$theme_path"
+  source $theme_path
+else
+  __load_system_fish_prompt
+end

--- a/themes/custom-theme/fish_prompt.fish
+++ b/themes/custom-theme/fish_prompt.fish
@@ -4,14 +4,6 @@ set -l oh_my_fish_path (status -f|command sed 's-/custom.*\?$--')
 set -l theme_path $oh_my_fish_path/themes/$fish_custom_theme/fish_prompt.fish
 set -l custom_path $oh_my_fish_path/custom/themes/$fish_custom_theme/fish_prompt.fish
 
-function __load_system_fish_prompt
-  if test -f /etc/fish/functions/fish_prompt.fish
-	 source /etc/fish/functions/fish_prompt.fish
-  else if test -f /usr/share/fish/functions/fish_prompt.fish
-  	 source /usr/share/fish/functions/fish_prompt.fish
-  end
-end
-
 # Assuming that if COLORTERM isn't set we are in a tty
 # In a tty fallback to system fish_prompt
 if not set -q COLORTERM

--- a/themes/custom-theme/fish_right_prompt.fish
+++ b/themes/custom-theme/fish_right_prompt.fish
@@ -1,40 +1,8 @@
 
-# Testing the current version of the theme against the current custom
-# Print a warning if the file has been changed.
-# Assuming classic installation, oh-my-fish is a git repo
 set -l oh_my_fish_path (status -f|sed 's-/custom.*\?$--')
-set -lx GIT_DIR "$oh_my_fish_path/.git"
-set -lx GIT_WORK_TREE "$oh_my_fish_path"
 
 set -l theme_path $oh_my_fish_path/themes/$fish_custom_theme/fish_right_prompt.fish
 set -l custom_path $oh_my_fish_path/custom/themes/$fish_custom_theme/fish_right_prompt.fish
-
-set -l theme_version __customtheme_theme_right_prompt_version_$fish_custom_theme
-set -l custom_version __customtheme_custom_right_prompt_version_$fish_custom_theme
-
-if git status > /dev/null ^&1
-  if test -f "$theme_path" ; and test -f "$custom_path"
-    set -l current_theme_version (git log -n 1 -- $theme_path | grep commit)
-    set -l current_custom_version (command ls -lon --time-style +%s "$custom_path"|\
-    sed 's- /.*$--;s/^\([^0-9]*[0-9]\+\)\{3\} //')
-
-    if not set -q $theme_version 
-  	   or not set -q $custom_version
-
-	   set -U $theme_version $current_theme_version
-	   set -U $custom_version $current_custom_version
-    else if not test $$theme_version = $current_theme_version
-	   if test $$custom_version = $current_custom_version
-  		  set_color red
-	  	  echo -e "The theme '$fish_custom_theme' has been changed.\nAn update to your fish_right_prompt.fish is necessary."
-  		  set_color normal
-	   else
-		  set -U $theme_version $current_theme_version
-  		  set -U $custom_version $current_custom_version
-	   end
-    end
-  end
-end
 
 function __load_system_fish_right_prompt
   if test -f /etc/fish/functions/fish_right_prompt.fish

--- a/themes/custom-theme/fish_right_prompt.fish
+++ b/themes/custom-theme/fish_right_prompt.fish
@@ -4,14 +4,6 @@ set -l oh_my_fish_path (status -f|sed 's-/custom.*\?$--')
 set -l theme_path $oh_my_fish_path/themes/$fish_custom_theme/fish_right_prompt.fish
 set -l custom_path $oh_my_fish_path/custom/themes/$fish_custom_theme/fish_right_prompt.fish
 
-function __load_system_fish_right_prompt
-  if test -f /etc/fish/functions/fish_right_prompt.fish
-	 source /etc/fish/functions/fish_right_prompt.fish
-  else if test -f /usr/share/fish/functions/fish_right_prompt.fish
-  	 source /usr/share/fish/functions/fish_right_prompt.fish
-  end
-end
-
 # Assuming that if COLORTERM isn't set we are in a tty
 # In a tty fallback to system fish_prompt
 if not set -q COLORTERM

--- a/themes/custom-theme/fish_right_prompt.fish
+++ b/themes/custom-theme/fish_right_prompt.fish
@@ -1,12 +1,14 @@
 
-set -l oh_my_fish_path (status -f|sed -r 's#(/custom)/themes/custom-theme.*?$##')
+set -l oh_my_fish_path (status -f|command sed -r 's#(/custom)?/themes/custom-theme.*?$##')
 
 set -l theme_path $oh_my_fish_path/themes/$fish_custom_theme/fish_right_prompt.fish
 set -l custom_path $oh_my_fish_path/custom/themes/$fish_custom_theme/fish_right_prompt.fish
 
 # Assuming that if COLORTERM isn't set we are in a tty
 # In a tty fallback to system fish_prompt
-if not set -q COLORTERM
+#if not set -q COLORTERM
+#  __load_system_fish_right_prompt
+if test x$TERM = x'linux'
   __load_system_fish_right_prompt
 else if test -f "$custom_path"
   source $custom_path

--- a/themes/custom-theme/fish_right_prompt.fish
+++ b/themes/custom-theme/fish_right_prompt.fish
@@ -1,0 +1,57 @@
+
+# Testing the current version of the theme against the current custom
+# Print a warning if the file has been changed.
+# Assuming classic installation, oh-my-fish is a git repo
+set -l oh_my_fish_path (status -f|sed 's-/custom.*\?$--')
+set -lx GIT_DIR "$oh_my_fish_path/.git"
+set -lx GIT_WORK_TREE "$oh_my_fish_path"
+
+set -l theme_path $oh_my_fish_path/themes/$fish_custom_theme/fish_right_prompt.fish
+set -l custom_path $oh_my_fish_path/custom/themes/$fish_custom_theme/fish_right_prompt.fish
+
+set -l theme_version __customtheme_theme_right_prompt_version_$fish_custom_theme
+set -l custom_version __customtheme_custom_right_prompt_version_$fish_custom_theme
+
+if git status > /dev/null ^&1
+  if test -f "$theme_path" ; and test -f "$custom_path"
+    set -l current_theme_version (git log -n 1 -- $theme_path | grep commit)
+    set -l current_custom_version (command ls -lon --time-style +%s "$custom_path"|\
+    sed 's- /.*$--;s/^\([^0-9]*[0-9]\+\)\{3\} //')
+
+    if not set -q $theme_version 
+  	   or not set -q $custom_version
+
+	   set -U $theme_version $current_theme_version
+	   set -U $custom_version $current_custom_version
+    else if not test $$theme_version = $current_theme_version
+	   if test $$custom_version = $current_custom_version
+  		  set_color red
+	  	  echo -e "The theme '$fish_custom_theme' has been changed.\nAn update to your fish_right_prompt.fish is necessary."
+  		  set_color normal
+	   else
+		  set -U $theme_version $current_theme_version
+  		  set -U $custom_version $current_custom_version
+	   end
+    end
+  end
+end
+
+function __load_system_fish_right_prompt
+  if test -f /etc/fish/functions/fish_right_prompt.fish
+	 source /etc/fish/functions/fish_right_prompt.fish
+  else if test -f /usr/share/fish/functions/fish_right_prompt.fish
+  	 source /usr/share/fish/functions/fish_right_prompt.fish
+  end
+end
+
+# Assuming that if COLORTERM isn't set we are in a tty
+# In a tty fallback to system fish_prompt
+if not set -q COLORTERM
+  __load_system_fish_right_prompt
+else if test -f "$custom_path"
+  source $custom_path
+else if test -f "$theme_path"
+  source $theme_path
+else
+  __load_system_fish_right_prompt
+end

--- a/themes/custom-theme/fish_right_prompt.fish
+++ b/themes/custom-theme/fish_right_prompt.fish
@@ -1,5 +1,5 @@
 
-set -l oh_my_fish_path (status -f|sed 's-/custom.*\?$--')
+set -l oh_my_fish_path (status -f|sed -r 's#(/custom)/themes/custom-theme.*?$##')
 
 set -l theme_path $oh_my_fish_path/themes/$fish_custom_theme/fish_right_prompt.fish
 set -l custom_path $oh_my_fish_path/custom/themes/$fish_custom_theme/fish_right_prompt.fish


### PR DESCRIPTION
# Custom Theme

If you don't want to read the README, you may skip to **Some technical stuff.**

## The README

### Why ?
  If you want to tinker with your favorite theme, custom-theme will tell you on a pull if an update has been done on the theme.

### What does it do ?

  The Plugin will check the latest commit of `(oh-my-fish-path)/themes/$fish_theme/fish_prompt.fish` and `(oh-my-fish-path)/themes/$fish_theme/fish_right_prompt.fish`.
  
  If this commit is more recent than the commit it has previously seen, custom-theme will print a warning.
  To aknowledge this warning, just update your custom theme or `touch (oh-my-fish-path)/themes/$fish_theme/fish_prompt.fish`


### Other Features

  Many themes use color and unicode that doesn't really fit a system tty ;
  * This is why custom-theme also perform a fallback on system `fish_prompt` if it detect that fish is launched from a ttyX.


### How to use ?

  This plugin also have a folder in `themes`, do not worry about that just add this plugin like any other `set fish_plugin custom-theme`


## Some technical stuff

* custom-theme is present in `(oh-my-fish)/plugins` and `(oh-my-fish)/themes`.

* custom-theme.load will override `$fish_theme` by `custom-theme` and store the content into `$fish_custom_theme`

* The theme will perform this check: 

 * If it detect that fish was launched from a tty, it will load the system fish_prompt
  (checking `if not set -q COLORTERM`, might have better way to do it)
 * will load the custom by default, if a switch is set by a call to customtheme_switch_vanilla (TODO)
 * If the user has set `$fish_theme to custom-theme` will load the system theme.

* The plugin will warn you if a change has been detected in `themes/$fish_plugin`
 * The plugin use git to get the latest change.
 It does so with the function `function __customtheme_check_prompt --on-event fish_prompt`


## Do not merge yet !

On my computer, at first the check is performed in 60ms, I now have reduced the time to 30ms. For reference my system fish_prompt take ~8.7ms.

I think it is still to high, __that is the main reason__ I want to wait before merging.
I'm still working on some others idea to reduce this time.

I just proposed this pull to get some feedback about the usefulness of this plugin. :smile: 

There are also some features I'm still working on.
