### PR TITLE
remember-last-dir plugin

### DIFF
--- a/plugins/remember-last-dir/remember-last-dir.load
+++ b/plugins/remember-last-dir/remember-last-dir.load
@@ -1,0 +1,5 @@
+function __remember_pwd_changes --on-variable PWD
+        set -U LAST_DIR $PWD
+end
+
+cd $LAST_DIR


### PR DESCRIPTION
Simple plugin to remember last working directory and 'cd' to it on startup.

There are two main use cases for me: 
* continuing work on some project after reboot
* splitting terminal window to launch tests/build/etc as a side job

I'm absolutely new to fish, so the code may need cleanup.