### PR TITLE
Add travis support via .travis.yml and bash bootstrap script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: c
+
+env:
+  - FISH_PPA=nightly-master
+
+before_install:
+  - script/bootstrap.sh
+
+script: fish ./spec/spec.fish

--- a/script/bootstrap.sh
+++ b/script/bootstrap.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+ppa=ppa:fish-shell/${FISH_PPA:-nightly-master}
+sudo add-apt-repository -y $ppa
+sudo apt-get update
+sudo apt-get -y install fish
+curl -L https://github.com/bpinto/oh-my-fish/raw/master/tools/install.fish | FORK=bucaran fish


### PR DESCRIPTION
The bootstrap script is currently installing my fork during the remote built test, again, this is because my build is the one with the most recent changes and to show it works.

Tests are passing! Checkout my master build [here](https://travis-ci.org/bucaran/oh-my-fish/builds/46844547). Notice this is build \#73 which is using my master branch, the most recent one \#74 is actually __failing__, but that's because it's pulling from my `travis` branch (this PR's branch), which does not have the `fish-spec` changes. You can ignore that ATM. 

(1) Let's merge first `travis`, and then (2) review the `fish-spec` branch. After that, you can (3) merge `fish-spec` and (4) add another commit yourself removing `FORK=bucaran` from `script/boostrap.sh`. Finally (5) I will pull from upstream master into my master.
