### PR TITLE
Stop test continue suite

### DIFF
--- a/oh-my-fish.fish
+++ b/oh-my-fish.fish
@@ -15,6 +15,7 @@ if not contains $fish_path/functions/ $fish_function_path
   set fish_function_path $fish_path/functions/ $fish_function_path
 end
 
+
 # Add imported plugins, completions and themes. Customize imported
 # commands via the $fish_path/custom directory, for example create
 # a directory under $fish_path/custom/themes with the same name as

--- a/oh-my-fish.fish
+++ b/oh-my-fish.fish
@@ -29,3 +29,6 @@ end
 
 # Prepend extracted user functions so they have the highest priority.
 set fish_function_path $user_function_path $fish_function_path
+
+# Make sure to exit with $status of 1 when reloading the framework.
+or true

--- a/plugins/fish-spec/expect.fish
+++ b/plugins/fish-spec/expect.fish
@@ -21,6 +21,12 @@
 #   spec.run
 #/
 function expect
+  # Abort if last call to `expect` finished with $status 1. This allows to
+  # stop individual tests from running if at least one expect call fails.
+  if [ $status -eq 1 ]
+    return 1
+  end
+
   set -l expected  $argv[1..-3]
   set -l condition $argv[-2]
   set -l actual    $argv[-1]

--- a/plugins/fish-spec/spec.eval.fish
+++ b/plugins/fish-spec/spec.eval.fish
@@ -81,6 +81,7 @@ function spec.eval -d "Eval a function by name and echo its description field."
     end
   end
 
+  set -l result 0
   for test in $tests
     if [ -z "$silent" ]
       set -l info (spec.get.info $tests)
@@ -91,6 +92,7 @@ function spec.eval -d "Eval a function by name and echo its description field."
       spec.log --message $default_color "$info"
     end
     eval $test
-      or return 1
+      or set result 1
   end
+  return $result
 end

--- a/plugins/fish-spec/spec.run.fish
+++ b/plugins/fish-spec/spec.run.fish
@@ -47,17 +47,14 @@ function spec.run
   spec.eval before_all $output
   for test in (spec.functions "it_")
     spec.eval before_each $output
-    # Stop test execution if an expectation fails.
+
+    # Flunk test if any single test fails, but do not stop the suite.
     if not spec.eval $test --unit --depth 1 $output
-      set result 1 # Flunk
+      set result 1
     end
 
-    # Make sure to run after_each if test fails.
+    # Make sure to run after_each even if a test fails.
     spec.eval after_each $output
-    if [ $result -eq 1 ]
-    # We can safely exit the loop if test fails.
-      break
-    end
   end
   spec.eval after_all $output
 

--- a/spec/oh-my-fish.spec.fish
+++ b/spec/oh-my-fish.spec.fish
@@ -57,7 +57,7 @@ function describe_oh_my_fish -d "Oh-My-Fish test spec..."
     set -g fish_plugins bak z
     load_oh_my_fish
     expect $fish_function_path --to-contain $fish_path/plugins/bak
-      and expect $fish_function_path --to-contain $fish_path/plugins/z
+    expect $fish_function_path --to-contain $fish_path/plugins/z
   end
 
   function it_loads_the_selected_theme \


### PR DESCRIPTION
There you go. Individual tests stop running if an expect fails or _anything fails inside the test function_, but the whole suite continues until the end. 