### PR TITLE
Fix some issues with the usage of RBENV_ROOT.

### DIFF
--- a/plugins/rbenv/rbenv.load
+++ b/plugins/rbenv/rbenv.load
@@ -1,15 +1,28 @@
-set -l rbenv_dir "$RBENV_ROOT"
-if [ ! $rbenv_dir ]
-  set rbenv_dir $HOME/.rbenv
+# Try to find rbenv by:
+# * Looking for $RBENV_BIN_ROOT/rbenv. This environment variable is specific to this plugin
+# * Looking for rbenv on $PATH
+# * Looking for rbenv in the user's home directory
+# When necessary, prepend the bin/ directory containing rbenv to our $PATH.
+if [ -e "$RBENV_BIN_ROOT/rbenv" ]
+  set rbenv_binary "$RBENV_BIN_ROOT/rbenv"
+  _prepend_path "$RBENV_BIN_ROOT"
+else if [ (command command -v rbenv) ]
+  set rbenv_binary (command command -v rbenv)
+else if [ -e "$HOME/.rbenv/bin/rbenv" ]
+  set rbenv_binary "$HOME/.rbenv/bin/rbenv"
+  _prepend_path "$HOME/.rbenv/bin"
+else
+  echo "Could not find rbenv. Make sure it's on your system path, in your home directory or set the RBENV_BIN_ROOT environment variable pointing to the directory where you unpacked rbenv."
+  exit 1
 end
 
 set -l supports_fish
 set -l supports_fish_version '0.4.0'
-set -l user_version (eval $rbenv_dir/bin/rbenv --version | sed -E 's/^rbenv ([[:digit:]\.]{2,}).*$/\1/g')
+set -l user_version (eval $rbenv_binary --version | sed -E 's/^rbenv ([[:digit:]\.]{2,}).*$/\1/g')
 
 if [ $user_version = $supports_fish_version ]
   set -l supports_fish_commits '56'
-  set -l user_commits (eval $rbenv_dir/bin/rbenv --version | sed -E 's/^.+-([[:digit:]]{1,}).+$/\1/g')
+  set -l user_commits (eval $rbenv_binary --version | sed -E 's/^.+-([[:digit:]]{1,}).+$/\1/g')
   if [ $user_commits -ge $supports_fish_commits ]
     set supports_fish true
   end
@@ -25,9 +38,12 @@ else
   end
 end
 
-_prepend_path $rbenv_dir/bin
 if [ $supports_fish ]
-  status --is-interactive; and source (eval $rbenv_dir/bin/rbenv init - | psub)
+  status --is-interactive; and source (eval $rbenv_binary init - | psub)
 else
-  _prepend_path $rbenv_dir/shims
+  if [ "$RBENV_ROOT" ]
+    _prepend_path "$RBENV_ROOT/shims"
+  else
+    _prepend_path "$HOME/.rbenv/shims"
+  end
 end


### PR DESCRIPTION
`RBENV_ROOT` can be used to relocate where rbenv ends up storing the shims
and versions of Ruby it installs. Because of this split `RBENV_ROOT`
cannot be used to reliably construct a path to the rbenv binary itself.

Instead we now rely on `$RBENV_BIN_ROOT` pointing to the `bin/` directory
containing the rbenv binary/script.

If `$RBENV_BIN_ROOT` is not set we search `$PATH` first and then the
user's home directory making sure to prepend the necessary directories to
our `$PATH` depending on where we find rbenv.

Lastly we prepend to our `$PATH` the location of `(rbenv root)/shims` so
that we can find the shims rbenv generates for us.