### PR TITLE
test runner should search fish_path for specs instead of *

### DIFF
--- a/script/run-tests.fish
+++ b/script/run-tests.fish
@@ -1,7 +1,7 @@
 #!/usr/bin/env fish
 
 set -l result 0
-for test in (find * -type f -print | grep "spec.fish")
+for test in (find $fish_path -type f -print | grep "spec.fish")
   fish $test $argv
     or set result 1
 end


### PR DESCRIPTION
If I move up a directory above my `oh-my-fish` installation and try `fish <oh-my-fish-directory>/script/run-tests.fish` it fails in my system because `find *` is greedy. We should be searching `fish_path` and not `*`.
