### PR TITLE
seq call in getopts should specify negative step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,3 @@ RUN /src/script/bootstrap.sh
 WORKDIR /root/.oh-my-fish
 
 CMD ["fish", "./script/run-tests.fish", "--verbose"]
-

--- a/plugins/getopts/getopts.fish
+++ b/plugins/getopts/getopts.fish
@@ -277,7 +277,7 @@ function getopts
           set -l tokens (printf $substring | tr : \n)
 
           # Start last to first to avoid mistaking long w/ short options.
-          for index in (seq (count $tokens) 1)
+          for index in (seq (count $tokens) -1 1)
             set -l last_token (printf $substring | tail -c1)
 
             # Find options with optional argument in long-style and


### PR DESCRIPTION
This fixes bugs in Ubuntu running on docker. OS X tests still pass. Travis build is falling.