### PR TITLE
Add pbcopy plugin. OSX's pbcopy and pbpaste for Linux.

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -22,6 +22,7 @@
 * [__msg__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/msg) - A technicolor message printer. A colorful alternative to echo.
 * [__ndenv__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/ndenv) – Helpers for [another node.js version manager](https://github.com/riywo/ndenv).
 * [__node__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/node) – Adds locally installed NodeJS `npm` binary executable modules to the path.
+* [__pbcopy__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/pbcopy) – OSX's pbcopy and pbpaste for Linux.
 * [__percol__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/percol) – Browse your fish history with [percol](https://github.com/mooz/percol).
 * [__peco__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/peco) – Browse your fish history with [peco](https://github.com/peco/peco).
 * [__osx__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/osx) - Integration with Finder and iTunes.

--- a/plugins/pbcopy/README.md
+++ b/plugins/pbcopy/README.md
@@ -1,0 +1,38 @@
+# pbcopy
+> OSX's pbcopy and pbpaste for Linux
+
+pbcopy paste data from the clipboard to STDOUT.
+pbpaste paste data from the clipboard.
+
+## Usage
+
+Copy a list of files in your home directory to the OS X clipboard:
+```fish
+$ ls ~ | pbcopy
+```
+
+Copy the contents of a file to the clipboard:
+```fish
+$ pbcopy < cookies.txt
+```
+
+Copy part of a file to the clipboard
+```fish
+$ grep 'ip address' serverlist.txt | pbcopy
+```
+
+Paste from your clipboard to stdout
+echo `pbpaste`
+```fish
+$ pbpaste
+```
+
+Paste from your clipboard to a file
+```fish
+$ pbpaste > clipboard.txt
+```
+
+Paste from your clipboard to a file in a remote host
+```fish
+$ pbpaste | ssh username@host 'cat > ~/myclipboard.txt'
+```

--- a/plugins/pbcopy/pbcopy.fish
+++ b/plugins/pbcopy/pbcopy.fish
@@ -1,0 +1,7 @@
+function pbcopy --description "Copy data from STDIN to the clipboard"
+  xsel --clipboard --input
+end
+
+function pbpaste  --description "Paste data from the Clipboard"
+  xsel --clipboard --output
+end


### PR DESCRIPTION
# pbcopy
> OSX's pbcopy and pbpaste for Linux

pbcopy paste data from the clipboard to STDOUT.
pbpaste paste data from the clipboard.

## Usage

Copy a list of files in your home directory to the OS X clipboard:
```fish
$ ls ~ | pbcopy
```

Copy the contents of a file to the clipboard:
```fish
$ pbcopy < cookies.txt
```

Copy part of a file to the clipboard
```fish
$ grep 'ip address' serverlist.txt | pbcopy
```

Paste from your clipboard to stdout
echo `pbpaste`
```fish
pbpaste

```

Paste from your clipboard to a file
```fish
pbpaste > clipboard.txt
```

Paste from your clipboard to a file in a remote host
```fish
pbpaste | ssh username@host 'cat > ~/myclipboard.txt'
```