### PR TITLE
Fixing 'RVM is not a function, selecting rubies with 'rvm use ...' will not work.'

### DIFF
--- a/plugins/rvm/rvm.fish
+++ b/plugins/rvm/rvm.fish
@@ -1,14 +1,16 @@
 function rvm -d 'Ruby enVironment Manager'
+
   # run RVM and capture the resulting environment
   set -l env_file (mktemp -t rvm.fish.XXXXXXXXXX)
-  bash -c '[ -e ~/.rvm/scripts/rvm ] && source ~/.rvm/scripts/rvm || source /usr/local/rvm/scripts/rvm; cd .;rvm "$@"; status=$?; env > "$0"; exit $status' $env_file $argv
+
+  bash -c '[ -e ~/.rvm/scripts/rvm ] && source ~/.rvm/scripts/rvm || source /usr/local/rvm/scripts/rvm; rvm "$@"; status=$?; env > "$0"; exit $status' $env_file $argv
 
   # grep the rvm_* *PATH RUBY_* GEM_* variables from the captured environment
   # exclude lines with _clr and _debug
   # apply rvm_* *PATH RUBY_* GEM_* variables from the captured environment
-
   and eval (grep '^rvm\|^[^=]*PATH\|^RUBY_\|^GEM_' $env_file |grep -v _clr |grep -v _debug| sed '/^[^=]*PATH/y/:/ /; s/^/set -xg /; s/=/ /; s/$/ ;/; s/(//; s/)//')
 
   # clean up
   rm -f $env_file
+
 end

--- a/plugins/rvm/rvm.load
+++ b/plugins/rvm/rvm.load
@@ -13,7 +13,8 @@ function __check_rvm --on-variable PWD --description 'Setup rvm on directory cha
         break
       else
         if begin ; test -s ".rvmrc" ; or test -s ".ruby-version" ; or test -s ".ruby-gemset" ; or test -s ".versions.conf" ; end
-          rvm reload 1>/dev/null 2>&1
+          rvm reload 1> /dev/null 2>&1
+          rvm rvmrc load 1>/dev/null 2>&1
           break
         else
           set cwd (dirname "$cwd")


### PR DESCRIPTION
RVM is not a function, selecting rubies with 'rvm use ...' will not work.

You need to change your terminal emulator preferences to allow login shell.
Sometimes it is required to use `/bin/bash --login` as the command.
Please visit https://rvm.io/integration/gnome-terminal/ for an example.