### PR TITLE
add new plugin: tiny

### DIFF
--- a/plugins/tiny/README.md
+++ b/plugins/tiny/README.md
@@ -1,0 +1,73 @@
+# _tiny_
+> git.io for the lazy
+
+## Synopsis
+
+```
+tiny [-u --user <username>]
+     [-r --repo <repository>]
+     [-c --code <vanity code>]
+     [-o --open]
+     [-h --help]
+
+tiny [-c --code] [-o --open] owned-repo/url
+```
+
+## Description
+Tap into [git.io](http://git.io), github's URL shortener service, to easily _shorten_ any github URL. The generated URL is printed to `stdout` and copied to the clipboard. You can optionally specify the `-o` flag to open it up on your browser too.
+
+## Options
+
+#### `-u --user`  
+Username. If omitted, the git global config is queried.
+
+#### `-r --repo`  
+Repository name.
+
+#### `-c --code`  
+Own code to setup a personal `vanity` URL. A regular short URL is generated if the specified code is not available.
+
+#### `-o --open`  
+Open the short URL in the browser.
+
+#### `-h --help`
+Display usage help.
+
+## Default Options
+
+It's possible to omit the `-u` option and just specify the `url` to shorten.
+
+```fish
+tiny my-awesome-repo
+```
+
+In this case, the username will be retrieved from your git configuration file. You can add your github username to git's configuration like this:
+
+```fish
+git config github.user <your username>
+```
+
+Another common use case is to simply copy paste an existing URL into the terminal:
+
+```fish
+tiny [-o --open] http://github.com/facebook/react
+```
+
+## Diagnostics
+
+  The following error codes are generated:
+
++ _1_  git.io failed to shorten the URL
+
++ _2_  invalid input or no input.
+
+
+## Links
+
+  + [git.io](http://git.io)
+  + [Github's URL shortener](https://github.com/blog/985-git-io-github-url-shortener)
+
+
+## License
+
+[MIT](http://opensource.org/licenses/MIT) © [Jorge Bucaran](https://bucaran.me)

--- a/plugins/tiny/spec/tiny.spec.fish
+++ b/plugins/tiny/spec/tiny.spec.fish
@@ -1,0 +1,43 @@
+import plugins/fish-spec
+import plugins/tiny
+
+function describe_tiny -d "tiny (git.io ULR shortener)"
+  function it_generates_a_short_url
+    expect (tiny -u facebook -r react | cut -d/ -f3) --to-equal git.io
+  end
+
+  function it_prints_usage_if_there_is_no_input
+    expect (tiny | grep USAGE) --to-equal "  USAGE"
+  end
+
+  function it_returns_1_if_gitio_fails
+    tiny https://notgithub.com/bad/url
+    expect $status --to-equal 1
+  end
+
+  function it_returns_2_if_there_is_an_invalid_option
+    set -l ignore_output (tiny --wrong-option)
+    expect $status --to-equal 2
+  end
+
+  function it_returns_2_if_there_is_no_user_or_repo_specified
+    set -l ignore_output (tiny)
+    expect $status --to-equal 2
+  end
+
+  function it_prints_usage_if_there_is_an_invalid_option
+    expect (tiny -x | grep USAGE) --to-equal "  USAGE"
+  end
+
+  function it_prints_help_if_no_global_user_is_configured
+    set github_user_copy (git config --local github.user)
+
+    git config --local github.user ""
+    expect (tiny --repo whos-repo | head -c7) --to-equal "Specify"
+    expect $status --to-equal 2
+
+    git config --local github.user "$github_user_copy"
+  end
+end
+
+spec.run $argv

--- a/plugins/tiny/tiny.fish
+++ b/plugins/tiny/tiny.fish
@@ -1,0 +1,130 @@
+# NAME
+#   tiny - tap into github's git.io URL shortener
+#
+# SYNOPSIS
+#   tiny [-u --user <username>]
+#        [-r --repo <repository>]
+#        [-c --code <vanity code>]
+#        [-o --open]
+#        [-h --help]
+#
+#   tiny [-c --code] [-o --open] owned-repo/url
+#
+# DESCRIPTION
+#   Tap into git.io, github's URL shortener service, to easily shorten any
+#   github URL. The generated URL is printed to `stdout` and copied to the
+#   clipboard. You can optionally specify the `-o` flag to open it up on
+#   your browser too.
+#
+# OPTIONS
+#   -u --user  Username. If omitted, query the git global config.
+#   -r --repo  Repository.
+#   -c --code  Own code to setup a personal `vanity` URL. A regular short
+#              URL is generated if the specified code is not available.
+#   -o --open  Open the short URL in the browser.
+#   -h --help  Display usage help.
+#
+# DEFAULT OPTIONS
+#   It's possible to omit the `-u` option and just specify the `url` to
+#   shorten.
+#
+#     tiny my-awesome-repo
+#
+#   In this case, the username will be retrieved from your git config.
+#   You can add your github username to git's config like this:
+#
+#     git config github.user <your username>
+#
+#   Another common use case is to simply copy paste an existing URL into
+#   the terminal:
+#
+#     tiny [-o --open] http://github.com/facebook/react
+#
+# DIAGNOSTICS
+#   The following error codes are generated:
+#     1  git.io failed to shorten the URL
+#     2  invalid input or no input
+#
+# LINKS
+#   github.com/blog/985-git-io-github-url-shortener
+# /
+
+import plugins/getopts
+
+set -g __GITHUB_URL         "https://github.com"
+set -g __GITHUB_USER        (git config github.user)
+
+set -g __TINY_ERR_BAD_URL   1
+set -g __TINY_ERR_BAD_INPUT 2
+
+function github.io -a url code
+  if test -n "$code"
+    set code -F code=$code
+  end
+  # Extract URL from the response an remove an annoying \r at the end.
+  curl -is http://git.io/ -F url="$url" $code \
+    | grep "Location: http" | cut -c11- \
+    | awk '{print substr($0, 1, length($0) - 1)}'
+end
+
+function tiny -d "get a git.io short URL"
+  while set opts (getopts ":o:open u:user: r:repo: c:code: h:help" $argv)
+    switch $opts[1]
+      case o
+        set open true
+      case u
+        set user $opts[2]
+      case r
+        set repo $opts[2]
+      case c
+        set code $opts[2]
+      case h
+        tiny.help
+    end
+  end
+
+  test $status -gt 1
+    and tiny.help
+    and return $__TINY_ERR_BAD_INPUT
+
+  if echo "$opts" | grep --silent "http"
+    set url "$opts"
+  else if test -n "$opts"
+    # To allow the covenience of `tiny [OPTS] repo` → `tiny [OPTS] -r repo`
+    set repo "$opts"
+  end
+
+  if not set -q url
+    if not set -q user
+      if not set -q repo
+        tiny.help
+        return $__TINY_ERR_BAD_INPUT
+      end
+
+      set user $__GITHUB_USER
+      if test -z "$user"
+        echo "Specify a username via the -u option or save it to your git config."
+        echo -sn (set_color ccc) "e.g., git config --global github.user"
+        echo (set_color yellow) "username"
+        return $__TINY_ERR_BAD_INPUT
+      end
+    end
+
+    set url "$__GITHUB_URL/$user/$repo" "$code"
+  end
+
+  set url (github.io $url)
+  if test -n "$url"
+    if test (uname) != "Darwin"
+      import plugins/pbcopy
+    end
+    # Print to stdout, copy to stderr pipe it into pbcopy.
+    echo "$url" | tee /dev/stderr ^| pbcopy ^/dev/null
+
+    set -q open
+      and open "$url"
+      or true
+  else
+    return $__TINY_ERR_BAD_URL
+  end
+end

--- a/plugins/tiny/tiny.help.fish
+++ b/plugins/tiny/tiny.help.fish
@@ -1,0 +1,12 @@
+function tiny.help
+  echo "
+  USAGE
+    tiny [-u --user <username>]
+         [-r --repo <repository>]
+         [-c --code <vanity code>]
+         [-o --open]
+         [-h --help]
+
+    tiny [-c --code] [-o --open] owned-repo/url
+  "
+end


### PR DESCRIPTION
# _tiny_
> git.io for the lazy

## Synopsis

```
tiny [-u --user <username>]
     [-r --repo <repository>]
     [-c --code <vanity code>]
     [-o --open]

tiny [-c --code] [-o --open] owned-repo/url
```

## Description
Tap into [git.io](http://git.io), github's URL shortener service, to easily _shorten_ any github URL. The generated URL is printed to `stdout` and copied to the clipboard. You can optionally specify the `-o` flag to open it up on your browser too.

## Options

#### `-u --user`  
Username. If omitted, the git global config is queried.

#### `-r --repo`  
Repository name.

#### `-c --code`  
Own code to setup a personal `vanity` URL. A regular short URL is generated if the specified code is not available.

#### `-o --open`  
Open the short URL in the browser.

## Default Options

It's possible to omit the `-u` option and just specify the `url` to shorten.

```fish
tiny my-awesome-repo
```

In this case, the username will be retrieved from your git global config. You can add your github username to git's config like this:

```fish
git config --global github.user <your username>
```

Another common use case is to simply copy paste an existing URL into the terminal:

```fish
tiny [-o --open] http://github.com/facebook/react
```

## Diagnostics

  The following error codes are generated:

+ _1_  the URL was invalid or git.io failed.

+ _2_  invalid input or no input.


## Links

  + [git.io](http://git.io)
  + [Github's URL shortener](https://github.com/blog/985-git-io-github-url-shortener)


## License

[MIT](http://opensource.org/licenses/MIT) © [Jorge Bucaran](https://bucaran.me)
