### PR TITLE
Two fixes for tab plugin

### DIFF
--- a/plugins/tab/tab.fish
+++ b/plugins/tab/tab.fish
@@ -7,6 +7,11 @@
 #     tab [PATH]            Open PATH in a new tab
 #     tab [CMD]             Open a new tab and execute CMD
 #     tab [PATH] [CMD] ...  You can prolly guess
+#
+# If you use iTerm and your default session profile isn't "Default Session",
+# override it in your config.fish
+#
+#     set -g tab_iterm_profile "MyProfile"
 
 function tab -d 'Open the current directory (or any other directory) in a new tab'
   set -l cmd ''
@@ -29,10 +34,14 @@ function tab -d 'Open the current directory (or any other directory) in a new ta
   switch $TERM_PROGRAM
 
   case 'iTerm.app'
+    set -l profile 'Default Session'
+    if set -q tab_iterm_profile
+      set profile $tab_iterm_profile
+    end
     osascript 2>/dev/null -e "
       tell application \"iTerm\"
         tell current terminal
-          launch session \"Default Session\"
+          launch session \"$profile\"
           tell the last session
             write text \"cd \\\"$cdto\\\"$cmd\"
           end tell

--- a/plugins/tab/tab.fish
+++ b/plugins/tab/tab.fish
@@ -12,12 +12,14 @@ function tab -d 'Open the current directory (or any other directory) in a new ta
   set -l cmd ''
   set -l cdto $PWD
 
-  if test (count $argv) -gt 0 -a -d $argv[1]
-    pushd . >/dev/null
-    cd $argv[1]
-    set cdto $PWD
-    set -e argv[1]
-    popd >/dev/null
+  if test (count $argv) -gt 0
+    if test -d $argv[1]
+      pushd . >/dev/null
+      cd $argv[1]
+      set cdto $PWD
+      set -e argv[1]
+      popd >/dev/null
+    end
   end
 
   if test (count $argv) -gt 0


### PR DESCRIPTION
iTerm2 users whose default session profile isn't called "Default Session" can override the session profile name by setting `tab_iterm_profile` in their fish config. This is a stopgap until the changes in iTerm2 nightly ship… then we'll be able to actually ask iTerm what profile is default.

Plus, fix an index bug I introduced during the last PR review. Sorry 'bout that :)