### PR TITLE
Fix getopts multiline

### DIFF
--- a/plugins/getopts/getopts.fish
+++ b/plugins/getopts/getopts.fish
@@ -122,7 +122,7 @@
 #   → http://pubs.opengroup.org/onlinepubs/7908799/xbd/utilconv.html
 #
 # AUTHORS
-#   Jorge Bucaran <@bucaran>
+#   Jorge Bucaran <jbucaran@me.com>
 #/
 function getopts
   # Currently supported return success/error conditions.
@@ -154,7 +154,7 @@ function getopts
 
     # Trim option string and collect required / optional options.
     if [ -n "$__getopts_optstr" ]
-      set __getopts_optstr (printf $__getopts_optstr | tr '[:space:]' \n)
+      set __getopts_optstr (printf $__getopts_optstr | tr -s '[:space:]' \n)
 
       # Setting the first token of the option string to `:` enables
       # strict mode. This causes getopts to abort the process if an

--- a/plugins/getopts/getopts.spec.fish
+++ b/plugins/getopts/getopts.spec.fish
@@ -137,6 +137,14 @@ function describe_getotps -d "fish getopts"
     expect (__getopts $options $args) --to-equal \
       "xyz(777)Abc(100)longlong-req(32)long-opt(!!!)D O N E"
   end
+
+  function it_handles_multiline_option_strings
+    set -l multiline_options "a:aaa
+                              b:bbb
+                              c:ccc
+                              d:ddd"
+    expect (__getopts $multiline_options -dcbabcd) --to-equal "dcbabcd"
+  end
 end
 
 spec.run $argv


### PR DESCRIPTION
getopts should handle multiline option strings.

See [getopts#6](https://github.com/bucaran/getopts/issues/6)