### PR TITLE
theme plugin: quick theme switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ If you want to install it manually, [keep reading](#manual-installation).
 
 ## Usage
 
-Enabling a new plugin or theme is as easy as it should be. Open your fish configuration file
-`~/.config/fish/config.fish` and specify the theme and the plugins you want to use.
+Enabling a new plugin or theme is as easy as it should be. Open your fish configuration file `~/.config/fish/config.fish` and specify the theme and the plugins you want to use.
 
-As an example, to enable rails and git plugins add this line `set fish_plugins git rails`
-to your configuration file.
+As an example, to enable rails and git plugins add this line `set fish_plugins git rails` to your configuration file.
+
+Before setting down on a theme, you might want to have a go with all themes using our quick [theme switcher](https://github.com/bpinto/oh-my-fish/blob/master/plugins/theme/README.md) by typing `theme --help` on your shell.
 
 ## Customization
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -37,6 +37,7 @@
 * [__ssh__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/ssh) – ssh conservative $TERM value helper.
 * [__sublime__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/sublime) – Creates `subl` command line shortcut to launch [Sublime Text editor](http://sublimetext.com/).
 * [__tab__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/tab) – Open the current directory (or any other directory) in a new tab.
+* [__theme__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/theme) – Quick theme switcher.
 * [__tiny__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/tiny) - tap into github's git.io URL shortener.
 * [__tmux__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/tmux) – Plugin to start tmux with support for 256 colours.
 * [__vi-mode__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/vi-mode) – Basic vi key bindings emulation for fish.

--- a/plugins/theme/README.md
+++ b/plugins/theme/README.md
@@ -1,4 +1,4 @@
-## _theme_ :point_left:
+## _theme_ :tophat:
 > Quick theme switcher.
 
 ## Description
@@ -35,4 +35,4 @@ Quick theme switcher for _Oh my fish_. _theme_ is smart to auto-complete as you 
 
 ## License
 
-MIT :sunglasses:
+MIT

--- a/plugins/theme/README.md
+++ b/plugins/theme/README.md
@@ -1,0 +1,38 @@
+## _theme_ :point_left:
+> Quick theme switcher.
+
+## Description
+Quick theme switcher for _Oh my fish_. _theme_ is smart to auto-complete as you type all the available _oh-my-fish_ themes.
+
+![mov](https://cloud.githubusercontent.com/assets/8317250/6200763/8593a226-b4c9-11e4-9845-597be49d3233.gif)
+
+
+## Options
+
+#### `theme <theme name>`
+
+  Quick switch to theme.
+
+#### `theme -l --list`
+
+  List available themes.
+
+#### `theme -r --restore`
+
+  Restore original theme.
+
+#### `theme -h --help`
+
+  Show usage help.
+
+## Authors
+
++ [Jorge Bucaran](https://github.com/bucaran)
+
+## Credits
+
++ Auto-completions thanks to [Bruno Pinto](https://github.com/bpinto).
+
+## License
+
+MIT :sunglasses:

--- a/plugins/theme/completions/theme.fish
+++ b/plugins/theme/completions/theme.fish
@@ -1,0 +1,4 @@
+# Add completions when the theme is loaded. Thanks Bruno!
+complete --command (basename -s.fish (status -f)) \
+  --arguments "(basename (theme.util.get.themes))" \
+  --description "Oh-my-fish theme"

--- a/plugins/theme/spec/theme.spec.fish
+++ b/plugins/theme/spec/theme.spec.fish
@@ -1,0 +1,54 @@
+import plugins/fish-spec
+import plugins/theme
+
+function describe_theme -d "theme: quick theme switcher"
+  function before_all
+    set -g __theme_test_last_theme $fish_theme
+  end
+
+  function it_changes_the_current_theme
+    theme bobthefish
+    expect $fish_theme --to-equal bobthefish
+      and expect $fish_function_path --to-contain-all $fish_path/themes/bobthefish
+  end
+
+  function it_restores_the_original_theme
+    theme bobthefish
+    theme -r
+    expect $fish_theme --to-equal $__theme_test_last_theme
+  end
+
+  function it_prints_usage_help
+    expect (theme -h | grep USAGE | sed -E 's/ //g') --to-equal "USAGE"
+  end
+
+  function it_prints_a_list_of_all_themes
+    set -l themes (theme -l)
+    for theme in $fish_custom/themes/* $fish_path/themes/*
+      set theme (basename "$theme")
+      expect (echo "$themes" | grep -o "$theme") --to-equal "$theme"
+    end
+  end
+
+  function it_highlights_the_currently_selected_theme
+    set -l themes (theme -l)
+    expect (echo "$themes" | grep -o "$fish_theme\*") --to-equal "$fish_theme*"
+  end
+
+  function it_can_reload_a_theme_multiple_times
+    theme bobthefish
+    theme fishface
+    theme bobthefish
+    expect $fish_theme --to-equal bobthefish
+      and expect $fish_function_path --to-contain-all $fish_path/themes/bobthefish
+      and expect $fish_function_path --to-not-contain-all $fish_path/themes/fishface
+  end
+
+  function it_returns_1_if_the_theme_does_not_exist
+    set -l improbable_theme ___(date +%s)___
+    set -l ignore_output (theme "$improbable_theme")
+    expect $status --to-equal 1
+  end
+end
+
+spec.run $argv

--- a/plugins/theme/theme.fish
+++ b/plugins/theme/theme.fish
@@ -1,0 +1,102 @@
+# NAME
+#   theme - quick theme switcher
+#
+# DESCRIPTION
+#   Quick theme switcher for Oh my fish. theme is smart to auto-complete
+#   as you type from the list available _oh-my-fish_ themes.
+#
+# SYNOPSIS
+#   theme <theme name>
+#         [-l --list]
+#         [-u --update]
+#         [-r --restore]
+#         [-h --help]
+#
+# OPTIONS
+#   theme <theme name>
+#     Quick switch to theme.
+#
+#   theme -l --list
+#     List available themes.
+#
+#   theme -u --update
+#     Update theme auto-completions.
+#
+#   theme -r --restore
+#     Restore original theme.
+#
+#   theme -h --help
+#     Show usage help.
+#
+# AUTHORS
+#   Jorge Bucaran <jbucaran@me.com>
+# /
+
+if not set -q __fish_theme_last
+  set -g __fish_theme_last $fish_theme
+end
+
+function theme -d "quick theme switcher"
+  set -l usage "
+    USAGE
+      $_ <theme name>
+        Quick switch to theme.
+
+      $_ -l --list
+        List available themes.
+
+      $_ -r --restore
+        Restore original theme.
+
+      $_ -h --help
+        Show usage help.
+  "
+  if test (count $argv) -gt 0
+    set -l option $argv[1]
+    switch $option
+      case -h --help help
+        echo $usage
+
+      case -l --list
+        set -l regex "[[:<:]]($fish_theme)[[:>:]]"
+        if test (uname) != "Darwin"
+          set regex "\b($fish_theme)\b"
+        end
+        set -l color green
+        basename -a (theme.util.get.themes) \
+          | column \
+          | sed -E "s/$regex/"(set_color $color)"\1*"(set_color normal)"/"
+        set_color normal
+
+      case -r --restore
+        if set -q __fish_theme_last
+          if test $__fish_theme_last != $fish_theme
+            theme.util.remove.current
+
+            set fish_theme $__fish_theme_last
+            . $fish_path/oh-my-fish.fish
+          end
+        end
+
+      case \*
+        if test -z "$option"
+          echo $usage
+
+        else if test -d $fish_custom/themes/$option -o \
+                     -d $fish_path/themes/$option
+
+          theme.util.remove.current
+
+          set fish_theme $option
+          . $fish_path/oh-my-fish.fish
+
+        else
+          echo (set_color f00)"`$option` is not a theme."(set_color normal) ^&2
+          theme --list
+          return 1
+        end
+    end
+  else
+    theme --list
+  end
+end

--- a/plugins/theme/theme.util.get.themes.fish
+++ b/plugins/theme/theme.util.get.themes.fish
@@ -1,0 +1,3 @@
+function theme.util.get.themes
+  printf "%s\n" $fish_path/themes/*
+end

--- a/plugins/theme/theme.util.remove.current.fish
+++ b/plugins/theme/theme.util.remove.current.fish
@@ -1,0 +1,16 @@
+function theme.util.remove.current
+  # Find previously loaded theme index in function path.
+  set -l index (contains -i -- \
+    $fish_custom/themes/$fish_theme $fish_function_path)
+
+  if test $status -gt 0
+  # Not a custom theme, try a default theme.
+    set index (contains -i -- \
+      $fish_path/themes/$fish_theme $fish_function_path)
+  end
+
+  if test -n "$index"
+    # So Long, and Thanks for All the Fish.
+    set -e fish_function_path[$index]
+  end
+end

--- a/templates/config.fish
+++ b/templates/config.fish
@@ -4,9 +4,10 @@ set fish_path $HOME/.oh-my-fish
 # Theme
 set fish_theme robbyrussell
 
-# Which plugins would you like to load? (plugins can be found in ~/.oh-my-fish/plugins/*)
+# All built-in plugins can be found at ~/.oh-my-fish/plugins/
 # Custom plugins may be added to ~/.oh-my-fish/custom/plugins/
-# Example format: set fish_plugins bundler z
+# Enable plugins by adding their name separated by a space to the line below.
+set fish_plugins theme
 
 # Path to your custom folder (default path is ~/.oh-my-fish/custom)
 #set fish_custom $HOME/dotfiles/oh-my-fish


### PR DESCRIPTION

## _theme_ :point_left:
> Quick theme switcher.

## Description
  Quick theme switcher for _Oh my fish_. _theme_ is smart to auto-complete as you type from the list available _oh-my-fish_ themes.

![mov](https://cloud.githubusercontent.com/assets/8317250/6200763/8593a226-b4c9-11e4-9845-597be49d3233.gif)

> Note: The video shows the older name of the plugin `try`. Please assume it is `theme`.

## Options

#### `theme <theme name>`

  Quick switch to theme.

#### `theme -l --list`

  List available themes.

#### `theme -u --update`

  Update theme auto-completions.

#### `theme -r --restore`

  Restore original theme.

#### `theme -h --help`

  Show usage help.

## Authors

+ [Jorge Bucaran](https://github.com/bucaran)

## License

MIT :sunglasses:
