### PR TITLE
add cal plugin for OS X

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -4,6 +4,7 @@
 * [__better-alias__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/better-alias) - Provide alias with auto completion.
 * [__brew__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/brew) – [Homebrew](http://brew.sh/) integration.
 * [__bundler__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/bundler) – Use Ruby's [Bundler](http://bundler.io/) automatically for some commands.
+* [__cal__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/cal) – Highlight the current day in cal output.
 * [__ccache__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/ccache) – Enable [ccache](http://ccache.samba.org/) to speed up compilation.
 * [__django__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/django) – Helper for Django Unit tests. Cleans the cached modules as well.
 * [__ec2__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/ec2) – Exports env variables for Amazon's EC2 management.

--- a/plugins/cal/cal.fish
+++ b/plugins/cal/cal.fish
@@ -1,0 +1,28 @@
+# NAME
+#   cal - builtin cal thin wrapper for OS X
+#
+# USAGE
+#   cal --color
+#     Highlight the current day in cal output.
+#
+#   See `man cal` to learn more about cal builtin.
+#
+# BUGS
+#   Hightlights all days matching the current date in year view.
+#
+# AUTHORS
+#   Jorge Bucaran <jbucaran@me.com>
+#/
+function cal
+  set -l color none
+  if set -l index (contains -i -- --color $argv)
+    # Delete our internal use-only --color option from arguments.
+    set -e argv[$index]
+    set color always
+  end
+  set -l today (date +%e | sed "s/ //g")
+
+  # Use command cal to run the original cal command and not our wrapper.
+  command cal $argv | env GREP_COLOR='1;93' \
+    grep -E --color=$color "$month\b$today\b|\$"
+end

--- a/plugins/cal/cal.spec.fish
+++ b/plugins/cal/cal.spec.fish
@@ -1,0 +1,22 @@
+# Skip test suite in Linux. cal already highlights the current day there.
+test (uname) != 'Darwin'
+  and exit 0
+
+import plugins/fish-spec
+import plugins/cal
+
+function describe_tiny -d "cal plugin"
+  function it_generates_different_escape_sequences_from_cal
+    # Process substitution is used in order to pipe cal output to diff
+    # without using files. diff exits with 1 if differences are found.
+    diff (cal | psub) (cal --color | psub) >/dev/null
+    expect $status --to-equal 1
+  end
+
+  function it_defaults_to_builtin_if_--color_option_is_not_used_x
+    diff (command cal | psub) (cal | psub) >/dev/null
+    expect $status --to-equal 0
+  end
+end
+
+spec.run $argv


### PR DESCRIPTION
Highlight the current day in cal output.

Not a big deal. It's something I did when I was toying with `diff` and `psub`, which I used in the tests.