### PR TITLE
Fix python version detection in theme bobthefish

### DIFF
--- a/themes/bobthefish/fish_prompt.fish
+++ b/themes/bobthefish/fish_prompt.fish
@@ -327,11 +327,11 @@ end
 function __bobthefish_virtualenv_python_version -d 'Get current python version'
   set -l python_version (readlink (which python))
   switch "$python_version"
-    case python2
+    case 'python2*'
       echo $__bobthefish_superscript_glyph[2]
-    case python3
+    case 'python3*'
       echo $__bobthefish_superscript_glyph[3]
-    case pypy
+    case 'pypy*'
       echo $__bobthefish_pypy_glyph
   end
 end


### PR DESCRIPTION
Relax the python version matching, so `python` that symlinks to either major versions (e.g. 2, 3) or minor versions (e.g. 2.7, 3.4) can be properly detected.

On OSX it is easy to reproduce,
```fish
$ vf tmp -p python3
(tempenv) $ readlink (which python)
# python3.4
```
Same case for python 2.7.

Note that currently both pypy and pypy3 have same display glyph. I simply relaxed their case pattern to be `pypy*`, but we could consider explicitly distinguish them in future (maybe having `p2` and `p3` superscript?)

