### PR TITLE
+ pyenv plugin should source (pyenv init - | psub).

### DIFF
--- a/plugins/pyenv/pyenv.load
+++ b/plugins/pyenv/pyenv.load
@@ -1,7 +1,7 @@
-if test -n "$PYENV_ROOT"
-  _prepend_path $PYENV_ROOT/bin
-  _prepend_path $PYENV_ROOT/shims
-else
-  _prepend_path $HOME/.pyenv/bin
-  _prepend_path $HOME/.pyenv/shims
+if not test -q PYENV_ROOT
+  set PYENV_ROOT $HOME/.pyenv
+end
+
+if status --is-interactive
+  . (pyenv init - | psub)
 end


### PR DESCRIPTION
```fish
if not test -q PYENV_ROOT
  set PYENV_ROOT $HOME/.pyenv
end

if status --is-interactive
  . (pyenv init - | psub)
end
```

It's not necessary to add anything to the path, `pyenv init -` already handles all that, and also:

+ Installs shims that capture `python` calls, so that we run the correct version.
+ Adds itself as well as the __currently__ selected `python`'s version downloaded packages to the `$PATH`.
+ Adds Completions.