### PR TITLE
Fix for better-alias plugin

### DIFF
--- a/plugins/better-alias/balias.fish
+++ b/plugins/better-alias/balias.fish
@@ -1,11 +1,10 @@
 function balias --argument alias command
   eval 'alias $alias $command'
   if expr $command : '^sudo '>/dev/null
-    set command (expr substr + $command 6 (expr length $command))
+    set command (echo "$command" | cut -c6-)
   end
   complete -c $alias -xa "(
     set -l cmd (commandline -pc | sed -e 's/^ *\S\+ *//' );
     complete -C\"$command \$cmd\";
   )"
 end
-

--- a/plugins/better-alias/balias.fish
+++ b/plugins/better-alias/balias.fish
@@ -1,6 +1,6 @@
 function balias --argument alias command
   eval 'alias $alias $command'
-  if expr match $command '^sudo '>/dev/null
+  if expr $command : '^sudo '>/dev/null
     set command (expr substr + $command 6 (expr length $command))
   end
   complete -c $alias -xa "(

--- a/plugins/better-alias/balias.spec.fish
+++ b/plugins/better-alias/balias.spec.fish
@@ -5,6 +5,7 @@ function describe_library -d "better-alias"
 
   function after_all
     functions -e changedir
+    functions -e ls_as_root
   end
 
   function it_doesnt_fail
@@ -23,6 +24,11 @@ function describe_library -d "better-alias"
     expect test $status --to-be-true
     cd ..
     rmdir testdir
+  end
+
+  function it_chops_off_sudo
+    balias ls_as_root 'sudo ls'
+    expect test $status --to-be-true
   end
 
 end

--- a/plugins/better-alias/balias.spec.fish
+++ b/plugins/better-alias/balias.spec.fish
@@ -1,0 +1,30 @@
+import plugins/fish-spec
+import plugins/balias
+
+function describe_library -d "better-alias"
+
+  function after_all
+    functions -e changedir
+  end
+
+  function it_doesnt_fail
+    balias changedir cd
+    expect test $status --to-be-true
+  end
+
+  function it_defines_an_alias
+    functions changedir
+    expect test $status --to-be-true
+  end
+
+  function you_can_use_the_alias
+    mkdir testdir
+    changedir testdir
+    expect test $status --to-be-true
+    cd ..
+    rmdir testdir
+  end
+
+end
+
+spec.run $argv


### PR DESCRIPTION
`better-alias` (`balias`) wasn't working for me out-of-the-box, on OSX Mavericks 10.9.5. After some testing, it turned out that the culprit was [the version of `expr` that comes with OSX](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/expr.1.html), which does not support the `expr match str1 str2` syntax. Instead, you have to use the (apparently older) syntax, `expr str1 : str2`. (See [this question on StackOverflow](http://stackoverflow.com/questions/25587446/syntax-error-expr) for more info.) After making this change, `balias` works as expected.

I tried the `expr str1 : str2` syntax in a Linux VM, and it works, so this change should make `balias` work for Mac users without breaking things for Linux users.