### PR TITLE
Add 'will' theme

### DIFF
--- a/themes/will/README.md
+++ b/themes/will/README.md
@@ -1,0 +1,7 @@
+## Will
+Minimalist theme.
+
+#### Characteristics
+* The current working directory is displayed on the right-side
+* Hostnames are displayed if and only if we're on an SSH connection
+* Uses logical entailment as the prompt character

--- a/themes/will/README.md
+++ b/themes/will/README.md
@@ -1,6 +1,8 @@
 ## Will
 Minimalist theme.
 
+![Screenshot](https://cloud.githubusercontent.com/assets/143746/6462675/60d171fe-c1ab-11e4-9434-8718a2139c79.png)
+
 #### Characteristics
 * The current working directory is displayed on the right-side
 * Hostnames are displayed if and only if we're on an SSH connection

--- a/themes/will/fish_prompt.fish
+++ b/themes/will/fish_prompt.fish
@@ -1,0 +1,10 @@
+function fish_prompt
+  if test -n "$SSH_CONNECTION"
+    printf '%s ' $HOSTNAME
+  end
+
+  set_color red
+  printf "⊨"
+  set_color normal
+  printf " "
+end

--- a/themes/will/fish_right_prompt.fish
+++ b/themes/will/fish_right_prompt.fish
@@ -1,0 +1,5 @@
+function fish_right_prompt
+  set_color red
+  printf '%s ' (prompt_pwd)
+  set_color normal
+end


### PR DESCRIPTION
Hello there,

I don't know if you still accept theme submission but here goes.

![Screenshot](https://cloud.githubusercontent.com/assets/143746/6462675/60d171fe-c1ab-11e4-9434-8718a2139c79.png)

A very simple theme, based on three things:
- Simple prompt with ⊨ (logical entailment, aka double turnstile)
- Working directory on the right
- Hostname only on SSH.

All the best,
/will