### PR TITLE
Add emacs plugin

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -7,6 +7,7 @@
 * [__ccache__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/ccache) – Enable [ccache](http://ccache.samba.org/) to speed up compilation.
 * [__django__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/django) – Helper for Django Unit tests. Cleans the cached modules as well.
 * [__ec2__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/ec2) – Exports env variables for Amazon's EC2 management.
+* [__emacs__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/emacs) – Wrapper for [daemon](http://www.emacswiki.org/emacs/EmacsAsDaemon) functionality of [Emacs](https://www.gnu.org/software/emacs/).
 * [__emoji-clock__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/emoji-clock) – The current time with half hour accuracy as an emoji symbol.
 * [__extract__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/extract) – Plugin to expand or extract bundled & compressed files.
 * [__fish-spec__](https://github.com/bpinto/oh-my-fish/tree/master/plugins/fish-spec) - Unit testing as simple as fish. See the [README](fish-spec/README.markdown) for usage instructions.

--- a/plugins/emacs/README.md
+++ b/plugins/emacs/README.md
@@ -1,0 +1,30 @@
+# Emacs Plugin
+
+This plugin replicates the functionality of the [emacs](https://www.gnu.org/software/emacs/) plugin for [oh-my-zsh](http://ohmyz.sh/).
+It is essentially a wrapper around the very useful [emacs daemon](http://www.emacswiki.org/emacs/EmacsAsDaemon) capability.
+
+Below is an extract from the original plugin source file:
+
+"Emacs 23 daemon capability is a killing feature.
+One emacs process handles all your frames whether
+you use a frame opened in a terminal via a ssh connection or X frames
+opened on the same host.
+Benefits are multiple
+
+  * You don't have the cost of starting Emacs all the time anymore
+  * Opening a file is as fast as Emacs does not have anything else to do.
+  * You can share opened buffered across opened frames.
+  * Configuration changes made at runtime are applied to all frames."
+
+
+### Usage
+
+To use this plugin add `emacs` to `fish_plugins` in you fish config file:
+
+```bash
+set fish_plugins emacs
+```
+
+### Requirements
+
+Emacs 23 or later is required for this plugin.

--- a/plugins/emacs/emacs.load
+++ b/plugins/emacs/emacs.load
@@ -9,7 +9,9 @@ function __major_version
 end
 
 function __set_editor
-  set -q EDITOR; or set -gx EDITOR emacs
+  if not set -q EDITOR
+    set -gx EDITOR emacs
+  end
 end
 
 function __add_functions_to_path
@@ -17,8 +19,12 @@ function __add_functions_to_path
   set fish_function_path $emacs_functions $fish_function_path
 end
 
-set -q __emacs; or set __emacs (which emacs)
-set -q __emacs_version; or set __emacs_version (__major_version $__emacs)
+if not set -q __emacs
+  set __emacs (which emacs)
+end
+if not set -q __emacs_version
+  set __emacs_version (__major_version $__emacs)
+end
 
 if test "$__emacs_version" -gt 23
   __set_editor

--- a/plugins/emacs/emacs.load
+++ b/plugins/emacs/emacs.load
@@ -1,0 +1,33 @@
+function __major_version
+  if test -n "$argv"
+    set -l full_metadata (eval $argv --version)
+    set -l full_version (echo $full_metadata | grep -o "[0-9]\+.[0-9]\+.[0-9]\+.[0-9]\+")
+    set -l major_version (echo $full_version | sed  "s/\..*//")
+  end
+
+  echo $major_version
+end
+
+function __set_editor
+  set -q EDITOR; or set -gx EDITOR emacs
+end
+
+function __add_functions_to_path
+  set emacs_functions $fish_path/plugins/emacs/functions
+  set fish_function_path $emacs_functions $fish_function_path
+end
+
+set -q __emacs; or set __emacs (which emacs)
+set -q __emacs_version; or set __emacs_version (__major_version $__emacs)
+
+if test "$__emacs_version" -gt 23
+  __set_editor
+  __add_functions_to_path
+end
+
+set -e emacs
+set -e emacs_version
+functions -e __major_version
+functions -e __plugins_path
+functions -e __set_editor
+functions -e __add_functions_to_path

--- a/plugins/emacs/functions/__kill_emacs.fish
+++ b/plugins/emacs/functions/__kill_emacs.fish
@@ -1,0 +1,3 @@
+function __kill_emacs
+  emacsclient --alternate-editor '' --eval '(kill-emacs)' 2>/dev/null
+end

--- a/plugins/emacs/functions/__launch_emacs.fish
+++ b/plugins/emacs/functions/__launch_emacs.fish
@@ -1,9 +1,9 @@
 function __launch_emacs
   set -l x (emacsclient --alternate-editor '' --eval '(x-display-list)' 2>/dev/null)
 
-  if begin; test -z "$x"; or test $x = nil; end
+  if test -z "$x" -o "$x" = nil
     emacsclient $argv --alternate-editor '' --create-frame
   else
-    or emacsclient $argv --alternate-editor ''
+    emacsclient $argv --alternate-editor ''
   end
 end

--- a/plugins/emacs/functions/__launch_emacs.fish
+++ b/plugins/emacs/functions/__launch_emacs.fish
@@ -1,0 +1,9 @@
+function __launch_emacs
+  set -l x (emacsclient --alternate-editor '' --eval '(x-display-list)' 2>/dev/null)
+
+  if begin; test -z "$x"; or test $x = nil; end
+    emacsclient $argv --alternate-editor '' --create-frame
+  else
+    or emacsclient $argv --alternate-editor ''
+  end
+end

--- a/plugins/emacs/functions/e.fish
+++ b/plugins/emacs/functions/e.fish
@@ -1,0 +1,3 @@
+function e
+  __launch_emacs $argv --no-wait
+end

--- a/plugins/emacs/functions/ec.fish
+++ b/plugins/emacs/functions/ec.fish
@@ -1,0 +1,3 @@
+function ec
+  __launch_emacs $argv --create-frame --no-wait
+end

--- a/plugins/emacs/functions/ecd.fish
+++ b/plugins/emacs/functions/ecd.fish
@@ -7,6 +7,5 @@ function ecd
     echo $dir
   else
     echo 'cannot deduce current buffer filename.' >/dev/stderr
-    return 1
   end
 end

--- a/plugins/emacs/functions/ecd.fish
+++ b/plugins/emacs/functions/ecd.fish
@@ -1,0 +1,12 @@
+function ecd
+  set -l cmd '(let ((buf-name (buffer-file-name (window-buffer))))
+             (if buf-name (file-name-directory buf-name)))'
+  set -l dir (__launch_emacs --eval $cmd | tr -d '\"')
+
+  if test -n "$dir"
+    echo $dir
+  else
+    echo 'cannot deduce current buffer filename.' >/dev/stderr
+    return 1
+  end
+end

--- a/plugins/emacs/functions/eeval.fish
+++ b/plugins/emacs/functions/eeval.fish
@@ -1,0 +1,3 @@
+function eeval
+  __launch_emacs --eval $argv
+end

--- a/plugins/emacs/functions/efile.fish
+++ b/plugins/emacs/functions/efile.fish
@@ -1,0 +1,5 @@
+function efile
+  set -l cmd '(buffer-file-name (window-buffer))'
+
+  __launch_emacs --eval $cmd | tr -d '\"'
+end

--- a/plugins/emacs/functions/eframe.fish
+++ b/plugins/emacs/functions/eframe.fish
@@ -1,0 +1,3 @@
+function eframe
+  __launch_emacs $argv --create-frame --no-wait
+end

--- a/plugins/emacs/functions/ek.fish
+++ b/plugins/emacs/functions/ek.fish
@@ -1,0 +1,3 @@
+function ek
+  __kill_emacs
+end

--- a/plugins/emacs/functions/emacs.fish
+++ b/plugins/emacs/functions/emacs.fish
@@ -1,0 +1,3 @@
+function emacs
+  __launch_emacs $argv --no-wait
+end

--- a/plugins/emacs/functions/emasc.fish
+++ b/plugins/emacs/functions/emasc.fish
@@ -1,0 +1,3 @@
+function emasc
+  __launch_emacs $argv --no-wait
+end

--- a/plugins/emacs/functions/emcas.fish
+++ b/plugins/emacs/functions/emcas.fish
@@ -1,0 +1,3 @@
+function emcas
+  __launch_emacs $argv --no-wait
+end

--- a/plugins/emacs/functions/et.fish
+++ b/plugins/emacs/functions/et.fish
@@ -1,0 +1,3 @@
+function et
+  __launch_emacs $argv --tty
+end

--- a/plugins/emacs/spec/emacs.spec.fish
+++ b/plugins/emacs/spec/emacs.spec.fish
@@ -1,0 +1,118 @@
+import plugins/fish-spec
+
+
+function describe_emacs
+
+  function before_all
+    set -g __emacs_current_editor $EDITOR
+    set -g __emacs_load_file $fish_path/plugins/emacs/emacs.load
+    set -g __emacs_functions e ec ek et ecd eeval efile eframe emacs emasc emcas
+  end
+
+  function before_each
+    set -e EDITOR
+    set -g __emacs '/bin/emacs'
+    set -g __emacs_version 25
+  end
+
+  function it_sets_editor_on_load
+    load_emacs_plugin
+
+    expect $EDITOR --to-equal "emacs"
+  end
+
+  function it_does_not_set_editor_when_it_is_already_set
+    set EDITOR 'vim'
+
+    load_emacs_plugin
+
+    expect $EDITOR --to-equal "vim"
+  end
+
+  function it_does_not_set_editor_when_emacs_is_not_found
+    emacs_is_not_found
+
+    load_emacs_plugin
+
+    expect "$EDITOR" --to-equal ""
+  end
+
+  function it_does_not_set_editor_when_emacs_version_is_lower_than_23
+    set __emacs_version 22
+
+    load_emacs_plugin
+
+    expect "$EDITOR" --to-equal ""
+  end
+
+  function it_adds_functions_to_fish_function_path
+    load_emacs_plugin
+
+    expect (functions) --to-contain-all $__emacs_functions
+  end
+
+  function it_has_a_test_helper_that_removes_emacs_functions
+    load_emacs_plugin
+
+    expect (functions) --to-contain-all $__emacs_functions
+
+    remove_emacs_functions
+
+    expect (functions) --to-not-contain-all $__emacs_functions
+  end
+
+
+  function it_does_not_add_functions_when_emacs_is_not_found
+    remove_emacs_functions
+    emacs_is_not_found
+
+    load_emacs_plugin
+
+    expect (functions) --to-not-contain-all $__emacs_functions
+  end
+
+  function it_does_not_add_functions_when_emacs_version_is_lower_than_23
+    set __emacs_version 22
+
+    expect (functions) --to-not-contain-all $__emacs_functions
+
+    load_emacs_plugin
+
+    expect (functions) --to-not-contain-all $__emacs_functions
+  end
+
+
+  function emacs_is_not_found
+    set __emacs ""
+    set __emacs_version ""
+  end
+
+  function load_emacs_plugin
+    source $__emacs_load_file
+  end
+
+  function remove_emacs_functions
+    for path in $fish_function_path
+      set match (echo $path | grep emacs)
+      if test -z "$match"
+        set -g __new_fish_function_path $__new_fish_function_path $path
+      end
+    end
+
+    set fish_function_path $__new_fish_function_path
+    set -e __new_fish_function_path
+  end
+
+  function after_all
+    set EDITOR $__emacs_current_editor
+
+    set -e __emacs
+    set -e __emacs_version
+    set -e __emacs_load_file
+    set -e __emacs_functions
+    set -e __emacs_current_editor
+  end
+end
+
+
+spec.run $argv


### PR DESCRIPTION
Incorporates changes after code reviews of #398 and #408

Port of oh-my-zsh emacs plugin.
Includes a function to kill emacs from command line once
a daemon has started.

More information included in plugins/emacs/README.md.

See reference plugin here:
https://github.com/robbyrussell/oh-my-zsh/tree/master/plugins/emacs
