### PR TITLE
append to config.fish instead of overwriting

### DIFF
--- a/templates/config.fish
+++ b/templates/config.fish
@@ -1,5 +1,5 @@
 # Path to your oh-my-fish.
-set fish_path $HOME/.oh-my-fish
+set fish_path $HOME/.oh-my-fish $PATH
 
 # Theme
 set fish_theme robbyrussell

--- a/tools/install.fish
+++ b/tools/install.fish
@@ -81,10 +81,13 @@ log blue "Looking for an existing fish config..."
 if test -f $config_path/config.fish
   log green "Found $config_path/config.fish."
   log green "Backing up to $config_path/config.orig"
-  mv $config_path/config.{fish,orig}
+  cp $config_path/config.{fish,orig}
+  log blue "Appending default configuration file to $config_path/config.fish"
+  cat $config_path/config.fish $fish_path/templates/config.fish > $config_path/config.fish
+else
+  log blue "Adding default configuration file to $config_path/config.fish"
+  cp $fish_path/templates/config.fish $config_path/config.fish
 end
-log blue "Adding default configuration file to $config_path/config.fish"
-cp $fish_path/templates/config.fish $config_path/config.fish
 
 # Print nice fish logo with colors.
 log green \


### PR DESCRIPTION
This is my proposed change. Fixes #439

if there is an existing config.fish, append to the end of it instead of overwriting.