### PR TITLE
FIxing a problem caused by the strange "command command -v rbenv" command

### DIFF
--- a/plugins/rbenv/rbenv.load
+++ b/plugins/rbenv/rbenv.load
@@ -6,11 +6,11 @@
 if [ -e "$RBENV_BIN_ROOT/rbenv" ]
   set rbenv_binary "$RBENV_BIN_ROOT/rbenv"
   _prepend_path "$RBENV_BIN_ROOT"
-else if [ (command command -v rbenv) ]
-  set rbenv_binary (command command -v rbenv)
 else if [ -e "$HOME/.rbenv/bin/rbenv" ]
   set rbenv_binary "$HOME/.rbenv/bin/rbenv"
   _prepend_path "$HOME/.rbenv/bin"
+else if [ (command command -v rbenv) ]
+  set rbenv_binary (command command -v rbenv)
 else
   echo "Could not find rbenv. Make sure it's on your system path, in your home directory or set the RBENV_BIN_ROOT environment variable pointing to the directory where you unpacked rbenv."
   exit 1

--- a/plugins/rbenv/rbenv.load
+++ b/plugins/rbenv/rbenv.load
@@ -6,11 +6,11 @@
 if [ -e "$RBENV_BIN_ROOT/rbenv" ]
   set rbenv_binary "$RBENV_BIN_ROOT/rbenv"
   _prepend_path "$RBENV_BIN_ROOT"
+else if [ (which command; and command command -v rbenv) ]
+  set rbenv_binary (command command -v rbenv)
 else if [ -e "$HOME/.rbenv/bin/rbenv" ]
   set rbenv_binary "$HOME/.rbenv/bin/rbenv"
   _prepend_path "$HOME/.rbenv/bin"
-else if [ (command command -v rbenv) ]
-  set rbenv_binary (command command -v rbenv)
 else
   echo "Could not find rbenv. Make sure it's on your system path, in your home directory or set the RBENV_BIN_ROOT environment variable pointing to the directory where you unpacked rbenv."
   exit 1


### PR DESCRIPTION
(see discussion on commit f4faa2e812c96c371fabee46d1c02e8cf2b3d6b2)

The fix inverts the position of the strange "command command -v rbenv" that fails noisily, so that the standard position for the rbenv file is evaluated first and the failing line doesn't need to be triggered in these cases.

Tested on my environment, it seems to work.