### PR TITLE
Adding newline prompt option to Agnoster

### DIFF
--- a/themes/agnoster/fish_prompt.fish
+++ b/themes/agnoster/fish_prompt.fish
@@ -146,6 +146,7 @@ end
 # ===========================
 
 function fish_prompt
+  set -g RETVAL $status
   if eval $PROMPT_ON_NEWLINE == "true"
     echo -n "╭─"
   end

--- a/themes/agnoster/fish_prompt.fish
+++ b/themes/agnoster/fish_prompt.fish
@@ -147,17 +147,12 @@ end
 
 function fish_prompt
   set -g RETVAL $status
-  if eval $PROMPT_ON_NEWLINE == "true"
-    echo -n "╭─"
-  end
-
-  prompt_status
-  prompt_user
-  prompt_dir
-  prompt_git
-  prompt_finish
-
-  if eval $PROMPT_ON_NEWLINE == "true"
-    echo -e "\n╰─"
-  end
+  # Check for existence and then value of $NEWLINE_ON_PROMPT.
+  [ $NEWLINE_ON_PROMPT ]; and [ $NEWLINE_ON_PROMPT = "true" ]; and echo -n "╭─";
+   prompt_status
+   prompt_user
+   prompt_dir
+   prompt_git
+   prompt_finish
+  [ $NEWLINE_ON_PROMPT ]; and [ $NEWLINE_ON_PROMPT = "true" ]; and echo -e "\n╰─";
 end

--- a/themes/agnoster/fish_prompt.fish
+++ b/themes/agnoster/fish_prompt.fish
@@ -154,5 +154,5 @@ function fish_prompt
    prompt_dir
    prompt_git
    prompt_finish
-  [ $NEWLINE_ON_PROMPT ]; and [ $NEWLINE_ON_PROMPT = "true" ]; and echo -e "\n╰─";
+  [ $NEWLINE_ON_PROMPT ]; and [ $NEWLINE_ON_PROMPT = "true" ]; and set_color -b normal; and echo -e "\n╰─";
 end

--- a/themes/agnoster/fish_prompt.fish
+++ b/themes/agnoster/fish_prompt.fish
@@ -146,10 +146,17 @@ end
 # ===========================
 
 function fish_prompt
-  set -g RETVAL $status
+  if eval $PROMPT_ON_NEWLINE == "true"
+    echo -n "╭─"
+  end
+
   prompt_status
   prompt_user
   prompt_dir
   prompt_git
   prompt_finish
+
+  if eval $PROMPT_ON_NEWLINE == "true"
+    echo -e "\n╰─"
+  end
 end


### PR DESCRIPTION
This is a fish port of the pending pull-request into oh-my-zsh discussed in this thread: 
https://github.com/robbyrussell/oh-my-zsh/pull/2984 by the user wenlock.
Adds ability to set env variable PROMPT_ON_NEWLINE = true.
Setting this causes prompt to display as indicated in attached image.
Image also shows results of tests before and after to demonstrate no breaking change.
![screenshot](https://cloud.githubusercontent.com/assets/2018130/7671242/269bf63c-fcbe-11e4-9927-b6d644981796.png)
